### PR TITLE
Initialize nfcSuccessPin and nfcFailPin

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1192,9 +1192,11 @@ void setup() {
   }
   if (espConfig::miscConfig.nfcSuccessPin && espConfig::miscConfig.nfcSuccessPin != 255) {
     pinMode(espConfig::miscConfig.nfcSuccessPin, OUTPUT);
+    digitalWrite(espConfig::miscConfig.nfcSuccessPin, !espConfig::miscConfig.nfcSuccessHL);
   }
   if (espConfig::miscConfig.nfcFailPin && espConfig::miscConfig.nfcFailPin != 255) {
     pinMode(espConfig::miscConfig.nfcFailPin, OUTPUT);
+    digitalWrite(espConfig::miscConfig.nfcFailPin, !espConfig::miscConfig.nfcFailHL);
   }
   if (espConfig::miscConfig.gpioActionPin && espConfig::miscConfig.gpioActionPin != 255) {
     pinMode(espConfig::miscConfig.gpioActionPin, OUTPUT);


### PR DESCRIPTION
When the device is powered on, the outputs for nfcSuccessPin and nfcFailPin are always LOW. However, when using common anode LEDs, both outputs appear "active" (i.e., they illuminate) until they are explicitly triggered.

This merge request addresses the issue by ensuring that the initial state of nfcSuccessPin and nfcFailPin is correctly set to avoid inadvertent activation.
