### PR TITLE
Implement NeoPixel status LED

### DIFF
--- a/data/misc.html
+++ b/data/misc.html
@@ -26,6 +26,9 @@
   
   <p><b>- HomeKey Events</b></p>
 
+  <label for="nfc-s-pin">Auth Success/Failure GPIO Pin (NeoPixel)</label>
+  <input type="number" name="nfc-neopixel-pin" id="nfc-neopixel-pin" placeholder="2" required value="%NFCNEOPIXELPIN%">
+
   <label for="nfc-s-pin">Auth Success GPIO Pin</label>
   <input type="number" name="nfc-s-pin" id="nfc-s-pin" placeholder="2" required value="%NFC1PIN%">
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,6 +31,7 @@ lib_deps =
 	https://github.com/rednblkx/HK-HomeKit-Lib.git#esp-idf-4
 	https://github.com/me-no-dev/ESPAsyncWebServer.git
 	https://github.com/joltwallet/esp_littlefs.git
+	adafruit/Adafruit NeoPixel@^1.12.2
 board_build.partitions = with_ota.csv
 extra_scripts = fs.py
 build_flags = 

--- a/src/config.h
+++ b/src/config.h
@@ -26,6 +26,7 @@
 #define HOMEKEY_ALWAYS_LOCK 0  // Flag indicating if a successful Homekey authentication should always set and publish the lock state
 #define HS_STATUS_LED 2 // HomeSpan Status LED GPIO pin
 #define HS_PIN 255 // GPIO Pin for a Configuration Mode button (more info on https://github.com/HomeSpan/HomeSpan/blob/master/docs/UserGuide.md#device-configuration-mode)
+#define NFC_NEOPIXEL_PIN 255 // GPIO Pin used for NeoPixel
 #define NFC_SUCCESS_PIN 255 // GPIO Pin pulled HIGH or LOW (see NFC_SUCCESS_HL) on success HK Auth
 #define NFC_SUCCESS_HL HIGH // Flag to define if NFC_SUCCESS_PIN should be held High or Low
 #define NFC_SUCCESS_TIME 1000 // How long should NFC_SUCCESS_PIN be held High or Low

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include <esp_ota_ops.h>
 #include <esp_task.h>
 #include <pins_arduino.h>
+#include <Adafruit_NeoPixel.h>
 
 const char* TAG = "MAIN";
 
@@ -70,6 +71,7 @@ namespace espConfig
     bool lockAlwaysLock = HOMEKEY_ALWAYS_LOCK;
     uint8_t controlPin = HS_PIN;
     uint8_t hsStatusPin = HS_STATUS_LED;
+    uint8_t nfcNeopixelPin = NFC_NEOPIXEL_PIN;
     uint8_t nfcSuccessPin = NFC_SUCCESS_PIN;
     uint16_t nfcSuccessTime = NFC_SUCCESS_TIME;
     bool nfcSuccessHL = NFC_SUCCESS_HL;
@@ -83,12 +85,14 @@ namespace espConfig
   } miscConfig;
 }
 JSONCONS_ALL_MEMBER_TRAITS(espConfig::mqttConfig_t, mqttBroker, mqttPort, mqttUsername, mqttPassword, mqttClientId, hkTopic, lockStateTopic, lockStateCmd, lockCStateCmd, lockTStateCmd, lockCustomStateTopic, lockCustomStateCmd, lockEnableCustomState, hassMqttDiscoveryEnabled, customLockStates, customLockActions)
-JSONCONS_ALL_MEMBER_TRAITS(espConfig::misc_config_t, deviceName, lockAlwaysUnlock, lockAlwaysLock, controlPin, hsStatusPin, nfcSuccessPin, nfcSuccessHL, nfcFailPin, nfcFailHL, gpioActionEnable, gpioActionPin, gpioActionLockState, gpioActionUnlockState, otaPasswd, setupCode)
+JSONCONS_ALL_MEMBER_TRAITS(espConfig::misc_config_t, deviceName, lockAlwaysUnlock, lockAlwaysLock, controlPin, hsStatusPin, nfcSuccessPin, nfcNeopixelPin, nfcSuccessHL, nfcFailPin, nfcFailHL, gpioActionEnable, gpioActionPin, gpioActionLockState, gpioActionUnlockState, otaPasswd, setupCode)
 
 KeyFlow hkFlow = KeyFlow::kFlowFAST;
 SpanCharacteristic* lockCurrentState;
 SpanCharacteristic* lockTargetState;
 esp_mqtt_client_handle_t client = nullptr;
+
+Adafruit_NeoPixel pixels(1, NFC_NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);
 
 bool save_to_nvs() {
   std::vector<uint8_t> cborBuf;
@@ -624,6 +628,9 @@ String miscHtmlProcess(const String& var) {
   else if (var == "LEDPIN") {
     return String(espConfig::miscConfig.hsStatusPin);
   }
+  else if (var == "NFCNEOPIXELPIN") {
+    return String(espConfig::miscConfig.nfcNeopixelPin);
+  }
   else if (var == "NFC1PIN") {
     return String(espConfig::miscConfig.nfcSuccessPin);
   }
@@ -895,6 +902,9 @@ void setupWeb() {
       else if (!strcmp(p->name().c_str(), "led-pin")) {
         espConfig::miscConfig.hsStatusPin = p->value().toInt();
       }
+      else if (!strcmp(p->name().c_str(), "nfc-neopixel-pin")) {
+        espConfig::miscConfig.nfcNeopixelPin = p->value().toInt();
+      }
       else if (!strcmp(p->name().c_str(), "nfc-s-pin")) {
         espConfig::miscConfig.nfcSuccessPin = p->value().toInt();
       }
@@ -1136,11 +1146,25 @@ void gpio_task(void* arg) {
             delay(espConfig::miscConfig.nfcSuccessTime);
             digitalWrite(espConfig::miscConfig.nfcSuccessPin, !espConfig::miscConfig.nfcSuccessHL);
           }
+          if (espConfig::miscConfig.nfcNeopixelPin && espConfig::miscConfig.nfcNeopixelPin != 255) {
+            pixels.setPixelColor(0, pixels.Color(0, 255, 0));
+            pixels.show();
+            delay(espConfig::miscConfig.nfcSuccessTime);
+            pixels.clear();
+            pixels.show();
+          }
         } else {
           if (espConfig::miscConfig.nfcFailPin && espConfig::miscConfig.nfcFailPin != 255) {
             digitalWrite(espConfig::miscConfig.nfcFailPin, espConfig::miscConfig.nfcFailHL);
             delay(espConfig::miscConfig.nfcFailTime);
             digitalWrite(espConfig::miscConfig.nfcFailPin, !espConfig::miscConfig.nfcFailHL);
+          }
+          if (espConfig::miscConfig.nfcNeopixelPin && espConfig::miscConfig.nfcNeopixelPin != 255) {
+            pixels.setPixelColor(0, pixels.Color(255, 0, 0));
+            pixels.show();
+            delay(espConfig::miscConfig.nfcFailTime);
+            pixels.clear();
+            pixels.show();
           }
         }
       }
@@ -1268,6 +1292,11 @@ void setup() {
   new Characteristic::Version();
   homeSpan.setControllerCallback(pairCallback);
   homeSpan.setWifiCallback(wifiCallback);
+  
+  if (espConfig::miscConfig.nfcNeopixelPin && espConfig::miscConfig.nfcNeopixelPin != 255) {
+    pixels.begin();
+  }
+
   xTaskCreate(gpio_task, "gpio_task", 4096, NULL, 1, NULL);
   xTaskCreate(nfc_thread_entry, "nfc_task", 8192, NULL, 2, NULL);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,7 +92,7 @@ SpanCharacteristic* lockCurrentState;
 SpanCharacteristic* lockTargetState;
 esp_mqtt_client_handle_t client = nullptr;
 
-Adafruit_NeoPixel pixels(1, NFC_NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);
+Adafruit_NeoPixel pixels(1, espConfig::miscConfig.nfcNeopixelPin, NEO_GRB + NEO_KHZ800);
 
 bool save_to_nvs() {
   std::vector<uint8_t> cborBuf;
@@ -1294,6 +1294,7 @@ void setup() {
   homeSpan.setWifiCallback(wifiCallback);
   
   if (espConfig::miscConfig.nfcNeopixelPin && espConfig::miscConfig.nfcNeopixelPin != 255) {
+    pixels.setPin(espConfig::miscConfig.nfcNeopixelPin);
     pixels.begin();
   }
 


### PR DESCRIPTION
Add support for NeoPixel status LED

Set NFC_NEOPIXEL_PIN to anything other than 255 to enable the feature.
LED will be green on success, red on failure.

Configuration from :
- config.h: handled
- web ui: handled