### PR TITLE
v0.3.1

### DIFF
--- a/.github/workflows/esp32.yml
+++ b/.github/workflows/esp32.yml
@@ -19,7 +19,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/cache@v4
         with:
           path: |

--- a/data/misc.html
+++ b/data/misc.html
@@ -26,6 +26,9 @@
   
   <p><b>- HomeKey Events</b></p>
 
+  <label for="nfc-s-pin">Auth Success/Failure GPIO Pin (NeoPixel)</label>
+  <input type="number" name="nfc-neopixel-pin" id="nfc-neopixel-pin" placeholder="2" required value="%NFCNEOPIXELPIN%">
+
   <label for="nfc-s-pin">Auth Success GPIO Pin</label>
   <input type="number" name="nfc-s-pin" id="nfc-s-pin" placeholder="2" required value="%NFC1PIN%">
 

--- a/data/misc.html
+++ b/data/misc.html
@@ -23,7 +23,27 @@
   <label for="hk-always-lock">Always Lock on HK Auth</label>
   <input type='hidden' name='hk-always-lock' value='0'>
   <input type="checkbox" name="hk-always-lock" id="hk-always-lock" value="1">
-  
+
+  <fieldset>
+    <legend>HomeKey Card Finish:</legend>
+    <div>
+      <label for="hk-tan">Tan</label>
+      <input type="radio" id="hk-finish-0" name="hk-hwfinish" value="0" />
+    </div>
+    <div>
+      <label for="hk-gold">Gold</label>
+      <input type="radio" id="hk-finish-1" name="hk-hwfinish" value="1" />
+    </div>
+    <div>
+      <label for="hk-silver">Silver</label>
+      <input type="radio" id="hk-finish-2" name="hk-hwfinish" value="2" />
+    </div>
+    <div>
+      <label for="hk-black">Black</label>
+      <input type="radio" id="hk-finish-3" name="hk-hwfinish" value="3" />
+    </div>
+  </fieldset>
+
   <p><b>- HomeKey Events</b></p>
 
   <label for="nfc-s-pin">Auth Success/Failure GPIO Pin (NeoPixel)</label>
@@ -79,6 +99,8 @@
   let gpioActionEn = "%GPIOAEN%" == true;
   let gpioActionLock = "%GPIOALOCK%" == true;
   let gpioActionUnlock = "%GPIOAUNLOCK%" == true;
+  let hwfinish = "%HWFINISH%";
+  document.getElementById(`hk-finish-${hwfinish}`).setAttribute("checked", "");
   if (nfcSuccessHL) {
     document.getElementById("nfc-s-hl").setAttribute("checked", "");
   }

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,6 +32,7 @@ lib_deps =
 	https://github.com/rednblkx/HK-HomeKit-Lib.git#esp-idf-4
 	https://github.com/me-no-dev/ESPAsyncWebServer.git
 	https://github.com/joltwallet/esp_littlefs.git
+	adafruit/Adafruit NeoPixel@^1.12.2
 board_build.partitions = with_ota.csv
 extra_scripts = fs.py
 build_flags = 

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,7 @@ default_envs = release
 
 [env]
 platform = espressif32
+platform_packages = platformio/tool-mklittlefs
 board = wemos_d1_mini32
 board_build.filesystem = littlefs
 framework = arduino, espidf
@@ -20,7 +21,7 @@ monitor_rts = 0
 monitor_dtr = 0
 monitor_speed = 115200
 monitor_echo = yes
-monitor_filters = 
+monitor_filters =
 	direct
 	esp32_exception_decoder
 ; 	log2file
@@ -43,6 +44,8 @@ build_type = debug
 
 [env:release]
 build_type = release
+build_flags = 
+  -Os
 build_unflags =
 	${env.build_unflags}
 	-Werror=all
@@ -61,4 +64,4 @@ platform = espressif32
 board = esp32-c3-devkitm-1
 build_type = release
 build_flags = 
-	-Os
+  -Os

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ monitor_filters =
 ; 	log2file
 lib_ldf_mode = deep
 lib_deps = 
-	https://github.com/rednblkx/HomeSpan.git#dev
+	https://github.com/rednblkx/HomeSpan.git#1.9.1
 	https://github.com/rednblkx/PN532.git#esp-idf-4
 	https://github.com/rednblkx/HK-HomeKit-Lib.git#esp-idf-4
 	https://github.com/me-no-dev/ESPAsyncWebServer.git

--- a/src/config.h
+++ b/src/config.h
@@ -19,7 +19,7 @@
 #define MQTT_STATE_TOPIC "topic/homekey/state" // MQTT Topic for publishing the HomeKit lock target state
 
 //Miscellaneous
-#define SETUP_CODE "46637726"  //code used for homekit setup
+#define SETUP_CODE ""  //code used for homekit setup
 #define OTA_PWD "homespan-ota" //custom password for ota
 #define DEVICE_NAME "HK" //Device name
 #define HOMEKEY_ALWAYS_UNLOCK 0 // Flag indicating if a successful Homekey authentication should always set and publish the unlock state

--- a/src/config.h
+++ b/src/config.h
@@ -44,7 +44,7 @@ enum customLockActions
 
 //Miscellaneous
 #define HOMEKEY_COLOR TAN
-#define SETUP_CODE "46637726"  //code used for homekit setup
+#define SETUP_CODE "46637726"  // HomeKit Setup Code (only for reference, has to be changed during WiFi Configuration or from WebUI)
 #define OTA_PWD "homespan-ota" //custom password for ota
 #define DEVICE_NAME "HK" //Device name
 #define HOMEKEY_ALWAYS_UNLOCK 0 // Flag indicating if a successful Homekey authentication should always set and publish the unlock state

--- a/src/config.h
+++ b/src/config.h
@@ -1,3 +1,11 @@
+enum HK_COLOR
+{
+  TAN,
+  GOLD,
+  SILVER,
+  BLACK
+};
+
 // MQTT Broker Settings
 #define MQTT_HOST "0.0.0.0" //IP adress of mqtt broker
 #define MQTT_PORT 1883 //Port of mqtt broker
@@ -19,7 +27,8 @@
 #define MQTT_STATE_TOPIC "topic/homekey/state" // MQTT Topic for publishing the HomeKit lock target state
 
 //Miscellaneous
-#define SETUP_CODE ""  //code used for homekit setup
+#define HOMEKEY_COLOR TAN
+#define SETUP_CODE "46637726"  //code used for homekit setup
 #define OTA_PWD "homespan-ota" //custom password for ota
 #define DEVICE_NAME "HK" //Device name
 #define HOMEKEY_ALWAYS_UNLOCK 0 // Flag indicating if a successful Homekey authentication should always set and publish the unlock state

--- a/src/config.h
+++ b/src/config.h
@@ -49,7 +49,7 @@ enum customLockActions
 #define DEVICE_NAME "HK" //Device name
 #define HOMEKEY_ALWAYS_UNLOCK 0 // Flag indicating if a successful Homekey authentication should always set and publish the unlock state
 #define HOMEKEY_ALWAYS_LOCK 0  // Flag indicating if a successful Homekey authentication should always set and publish the lock state
-#define HS_STATUS_LED 2 // HomeSpan Status LED GPIO pin
+#define HS_STATUS_LED 255 // HomeSpan Status LED GPIO pin
 #define HS_PIN 255 // GPIO Pin for a Configuration Mode button (more info on https://github.com/HomeSpan/HomeSpan/blob/master/docs/UserGuide.md#device-configuration-mode)
 #define NFC_NEOPIXEL_PIN 255 // GPIO Pin used for NeoPixel
 #define NFC_SUCCESS_PIN 255 // GPIO Pin pulled HIGH or LOW (see NFC_SUCCESS_HL) on success HK Auth

--- a/src/config.h
+++ b/src/config.h
@@ -26,6 +26,7 @@
 #define HOMEKEY_ALWAYS_LOCK 0  // Flag indicating if a successful Homekey authentication should always set and publish the lock state
 #define HS_STATUS_LED 2 // HomeSpan Status LED GPIO pin
 #define HS_PIN 255 // GPIO Pin for a Configuration Mode button (more info on https://github.com/HomeSpan/HomeSpan/blob/master/docs/UserGuide.md#device-configuration-mode)
+#define NFC_NEOPIXEL_PIN 255 // GPIO Pin used for NeoPixel
 #define NFC_SUCCESS_PIN 255 // GPIO Pin pulled HIGH or LOW (see NFC_SUCCESS_HL) on success HK Auth
 #define NFC_SUCCESS_HL HIGH // Flag to define if NFC_SUCCESS_PIN should be held High or Low
 #define NFC_SUCCESS_TIME 1000 // How long should NFC_SUCCESS_PIN be held High or Low

--- a/src/config.h
+++ b/src/config.h
@@ -6,6 +6,22 @@ enum HK_COLOR
   BLACK
 };
 
+enum customLockStates
+{
+  C_LOCKED = 1,
+  C_UNLOCKING = 2,
+  C_UNLOCKED = 3,
+  C_LOCKING = 4,
+  C_JAMMED = 254,
+  C_UNKNOWN = 255
+};
+// Custom Lock Actions to be used in MQTT_CUSTOM_STATE_TOPIC
+enum customLockActions
+{
+  UNLOCK = 1,
+  LOCK = 2
+};
+
 // MQTT Broker Settings
 #define MQTT_HOST "0.0.0.0" //IP adress of mqtt broker
 #define MQTT_PORT 1883 //Port of mqtt broker

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,7 @@ QueueHandle_t gpio_led_handle = nullptr;
 nvs_handle savedData;
 readerData_t readerData;
 uint8_t ecpData[18] = { 0x6A, 0x2, 0xCB, 0x2, 0x6, 0x2, 0x11, 0x0 };
+std::map<HK_COLOR, const char*> hk_color_vals = {{TAN, "AQTO1doA"}, {GOLD, "AQSq1uwA"}, {SILVER, "AQTj4+MA"}, {BLACK, "AQQAAAAA"}};
 namespace espConfig
 {
   struct mqttConfig_t
@@ -66,6 +67,7 @@ namespace espConfig
   {
     std::string deviceName = DEVICE_NAME;
     std::string otaPasswd = OTA_PWD;
+    std::string hk_key_color = hk_color_vals[HOMEKEY_COLOR];
     std::string setupCode = SETUP_CODE;
     bool lockAlwaysUnlock = HOMEKEY_ALWAYS_UNLOCK;
     bool lockAlwaysLock = HOMEKEY_ALWAYS_LOCK;
@@ -85,7 +87,7 @@ namespace espConfig
   } miscConfig;
 }
 JSONCONS_ALL_MEMBER_TRAITS(espConfig::mqttConfig_t, mqttBroker, mqttPort, mqttUsername, mqttPassword, mqttClientId, hkTopic, lockStateTopic, lockStateCmd, lockCStateCmd, lockTStateCmd, lockCustomStateTopic, lockCustomStateCmd, lockEnableCustomState, hassMqttDiscoveryEnabled, customLockStates, customLockActions)
-JSONCONS_ALL_MEMBER_TRAITS(espConfig::misc_config_t, deviceName, lockAlwaysUnlock, lockAlwaysLock, controlPin, hsStatusPin, nfcSuccessPin, nfcNeopixelPin, nfcSuccessHL, nfcFailPin, nfcFailHL, gpioActionEnable, gpioActionPin, gpioActionLockState, gpioActionUnlockState, otaPasswd, setupCode)
+JSONCONS_ALL_MEMBER_TRAITS(espConfig::misc_config_t, deviceName, hk_key_color, lockAlwaysUnlock, lockAlwaysLock, controlPin, hsStatusPin, nfcSuccessPin, nfcNeopixelPin, nfcSuccessHL, nfcFailPin, nfcFailHL, gpioActionEnable, gpioActionPin, gpioActionLockState, gpioActionUnlockState, otaPasswd, setupCode)
 
 KeyFlow hkFlow = KeyFlow::kFlowFAST;
 SpanCharacteristic* lockCurrentState;
@@ -1283,7 +1285,7 @@ void setup() {
   serialNumber.append(macStr);
   new Characteristic::SerialNumber(serialNumber.c_str());
   new Characteristic::FirmwareRevision(app_version.c_str());
-  new Characteristic::HardwareFinish();
+  new Characteristic::HardwareFinish(espConfig::miscConfig.hk_key_color.c_str());
 
   new LockManagement();
   new LockMechanism();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -900,8 +900,10 @@ void setupWeb() {
       }
       else if (!strcmp(p->name().c_str(), "hk-setupcode")) {
         if (strcmp(espConfig::miscConfig.setupCode.c_str(), p->value().c_str()) && p->value().length() == 8) {
-          homeSpan.setPairingCode(p->value().c_str());
-          espConfig::miscConfig.setupCode = p->value().c_str();
+          if (homeSpan.controllerListBegin() == homeSpan.controllerListEnd()) {
+            homeSpan.setPairingCode(p->value().c_str());
+            espConfig::miscConfig.setupCode = p->value().c_str();
+          }
         }
       }
       else if (!strcmp(p->name().c_str(), "control-pin")) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -974,7 +974,9 @@ void mqttConfigReset(const char* buf) {
 }
 
 void wifiCallback() {
-  mqtt_app_start();
+  if (strcmp(espConfig::mqttData.mqttBroker.c_str(), "0.0.0.0")) {
+    mqtt_app_start();
+  }
   setupWeb();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -884,9 +884,9 @@ void setupWeb() {
         espConfig::miscConfig.otaPasswd = p->value().c_str();
       }
       else if (!strcmp(p->name().c_str(), "hk-setupcode")) {
-        espConfig::miscConfig.setupCode = p->value().c_str();
-        if (strcmp(espConfig::miscConfig.setupCode.c_str(), "46637726")) {
-          homeSpan.setPairingCode(espConfig::miscConfig.setupCode.c_str());
+        if (strcmp(espConfig::miscConfig.setupCode.c_str(), p->value().c_str()) && p->value().length() == 8) {
+          homeSpan.setPairingCode(p->value().c_str());
+          espConfig::miscConfig.setupCode = p->value().c_str();
         }
       }
       else if (!strcmp(p->name().c_str(), "control-pin")) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1053,8 +1053,8 @@ void nfc_thread_entry(void* arg) {
             if (espConfig::mqttData.lockEnableCustomState) {
               mqtt_publish(espConfig::mqttData.lockCustomStateTopic, std::to_string(espConfig::mqttData.customLockActions["UNLOCK"]), 0, false);
             }
-          else if (espConfig::miscConfig.lockAlwaysLock) {
           }
+          else if (espConfig::miscConfig.lockAlwaysLock) {
             lockCurrentState->setVal(lockStates::LOCKED);
             lockTargetState->setVal(lockStates::LOCKED);
             if (espConfig::miscConfig.gpioActionEnable && espConfig::miscConfig.gpioActionPin != 255) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,8 +59,8 @@ namespace espConfig
     /* Flags */
     bool lockEnableCustomState = MQTT_CUSTOM_STATE_ENABLED;
     bool hassMqttDiscoveryEnabled = MQTT_DISCOVERY;
-    std::map<const char *, int> customLockStates = {{"C_LOCKED", 1}, {"C_UNLOCKING", 2}, {"C_UNLOCKED", 3}, {"C_LOCKING", 4}, {"C_JAMMED", 254}, {"C_UNKNOWN", 255}};
-    std::map<const char *, int> customLockActions = {{"UNLOCK", 1}, {"LOCK", 2}};
+    std::map<const char *, int> customLockStates = {{"C_LOCKED", C_LOCKED}, {"C_UNLOCKING", C_UNLOCKING}, {"C_UNLOCKED", C_UNLOCKED}, {"C_LOCKING", C_LOCKING}, {"C_JAMMED", C_JAMMED}, {"C_UNKNOWN", C_UNKNOWN}};
+    std::map<const char *, int> customLockActions = {{"UNLOCK", UNLOCK}, {"LOCK", LOCK}};
   } mqttData;
 
   struct misc_config_t

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -885,6 +885,9 @@ void setupWeb() {
       }
       else if (!strcmp(p->name().c_str(), "hk-setupcode")) {
         espConfig::miscConfig.setupCode = p->value().c_str();
+        if (strcmp(espConfig::miscConfig.setupCode.c_str(), "46637726")) {
+          homeSpan.setPairingCode(espConfig::miscConfig.setupCode.c_str());
+        }
       }
       else if (!strcmp(p->name().c_str(), "control-pin")) {
         espConfig::miscConfig.controlPin = p->value().toInt();
@@ -1212,9 +1215,6 @@ void setup() {
   homeSpan.setStatusPin(espConfig::miscConfig.hsStatusPin);
   homeSpan.setStatusAutoOff(15);
   homeSpan.reserveSocketConnections(2);
-  if (strcmp(espConfig::miscConfig.setupCode.c_str(), "46637726")) {
-    homeSpan.setPairingCode(espConfig::miscConfig.setupCode.c_str());
-  }
   homeSpan.setLogLevel(0);
   homeSpan.setSketchVersion(app_version.c_str());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,8 +57,8 @@ namespace espConfig
     /* Flags */
     bool lockEnableCustomState = MQTT_CUSTOM_STATE_ENABLED;
     bool hassMqttDiscoveryEnabled = MQTT_DISCOVERY;
-    std::map<string, int> customLockStates = {{"C_LOCKED", 1}, {"C_UNLOCKING", 2}, {"C_UNLOCKED", 3}, {"C_LOCKING", 4}, {"C_JAMMED", 254}, {"C_UNKNOWN", 255}};
-    std::map<string, int> customLockActions = {{"UNLOCK", 1}, {"LOCK", 2}};
+    std::map<const char *, int> customLockStates = {{"C_LOCKED", 1}, {"C_UNLOCKING", 2}, {"C_UNLOCKED", 3}, {"C_LOCKING", 4}, {"C_JAMMED", 254}, {"C_UNKNOWN", 255}};
+    std::map<const char *, int> customLockActions = {{"UNLOCK", 1}, {"LOCK", 2}};
   } mqttData;
 
   struct misc_config_t

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -945,6 +945,7 @@ void setupWeb() {
     }
 
     request->send(200, "text/plain", "Received Config, Restarting...");
+    delay(1000);
     ESP.restart();
     });
   webServer.onNotFound(notFound);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1239,7 +1239,9 @@ void setup() {
   if (espConfig::miscConfig.controlPin != 255) {
     homeSpan.setControlPin(espConfig::miscConfig.controlPin);
   }
-  homeSpan.setStatusPin(espConfig::miscConfig.hsStatusPin);
+  if (espConfig::miscConfig.hsStatusPin != 255) {
+   homeSpan.setStatusPin(espConfig::miscConfig.hsStatusPin);
+  }
   homeSpan.setStatusAutoOff(15);
   homeSpan.reserveSocketConnections(2);
   homeSpan.setLogLevel(0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,7 +67,7 @@ namespace espConfig
   {
     std::string deviceName = DEVICE_NAME;
     std::string otaPasswd = OTA_PWD;
-    std::string hk_key_color = hk_color_vals[HOMEKEY_COLOR];
+    uint8_t hk_key_color = HOMEKEY_COLOR;
     std::string setupCode = SETUP_CODE;
     bool lockAlwaysUnlock = HOMEKEY_ALWAYS_UNLOCK;
     bool lockAlwaysLock = HOMEKEY_ALWAYS_LOCK;
@@ -672,6 +672,9 @@ String miscHtmlProcess(const String& var) {
   else if (var == "GPIOAUNLOCK") {
     return String(espConfig::miscConfig.gpioActionUnlockState);
   }
+  else if (var == "HWFINISH") {
+    return String(espConfig::miscConfig.hk_key_color);
+  }
   return String();
 }
 
@@ -945,6 +948,9 @@ void setupWeb() {
       }
       else if (!strcmp(p->name().c_str(), "gpio-a-unlock")) {
         espConfig::miscConfig.gpioActionUnlockState = p->value().toInt();
+      }
+      else if (!strcmp(p->name().c_str(), "hk-hwfinish")) {
+        espConfig::miscConfig.hk_key_color = p->value().toInt();
       }
     }
     try {
@@ -1292,7 +1298,7 @@ void setup() {
   serialNumber.append(macStr);
   new Characteristic::SerialNumber(serialNumber.c_str());
   new Characteristic::FirmwareRevision(app_version.c_str());
-  std::vector<uint8_t> decB64 = utils::decodeB64(espConfig::miscConfig.hk_key_color.c_str());
+  std::vector<uint8_t> decB64 = utils::decodeB64(hk_color_vals[HK_COLOR(espConfig::miscConfig.hk_key_color)]);
   TLV8 hwfinish(NULL, 0);
   hwfinish.unpack(decB64.data(), decB64.size());
   new Characteristic::HardwareFinish(hwfinish);
@@ -1304,7 +1310,7 @@ void setup() {
   new Characteristic::Version();
   homeSpan.setControllerCallback(pairCallback);
   homeSpan.setWifiCallback(wifiCallback);
-  
+
   if (espConfig::miscConfig.nfcNeopixelPin && espConfig::miscConfig.nfcNeopixelPin != 255) {
     pixels.setPin(espConfig::miscConfig.nfcNeopixelPin);
     pixels.begin();


### PR DESCRIPTION
 - Initialize the NFC LED Pins according to option stored(HIGH or LOW)
 - `setPairingCode` no longer being called every reboot when using a custom setup code
 - Fixed mklittlefs dependency
 - Implemented NeoPixel support for the NFC Status LED, kudos @jess-sys
 - Configurable HomeKey Card Finish (color) from Web UI = Tan, Gold, Silver and Black
 - QoL stuff and fixes