### PR TITLE
Add Battery reporting from a Smart Lock

### DIFF
--- a/data/routes/misc.html
+++ b/data/routes/misc.html
@@ -14,18 +14,16 @@
                     <span style="height: 1px;border-top: 1px #424242 solid;display: block;margin: 0;padding: 0;"></span>
                 </div>
                 <div class="custom-tabs-selected-body" data-custom-tabs-body="0">
-                    <div style="display: flex;flex-direction: column;">
+                    <div style="display: flex;gap: 8px;">
                         <label for="device-name">Device Name</label>
                         <input type="text" name="device-name" id="device-name" placeholder="HK" required value="%DEVICENAME%"
                             style="width: fit-content;" />
                     </div>
-    
-                    <div style="display: flex;flex-direction: column;">
+                    <div style="display: flex;gap: 8px;">
                         <label for="hk-setupcode">Setup Code</label>
                         <input type="number" name="hk-setupcode" id="hk-setupcode" placeholder="46637726" required
                             value="%HKSETUPCODE%" style="width: fit-content;" />
                     </div>
-    
                     <div style="display: flex;gap: 8px;">
                         <label for="hk-always-lock">Always Lock on HomeKey</label>
                         <select name="hk-always-lock" id="hk-always-lock">
@@ -39,6 +37,17 @@
                             <option value="0">Disabled</option>
                             <option value="1">Enabled</option>
                         </select>
+                    </div>
+                    <div style="display: flex;gap: 8px;">
+                        <label for="prox-bat-enable">SmartLock battery reporting</label>
+                        <select name="prox-bat-enable" id="prox-bat-enable">
+                            <option value="0">Disabled</option>
+                            <option value="1">Enabled</option>
+                        </select>
+                    </div>
+                    <div style="display: flex;gap: 8px;">
+                        <label for="btr-low-threshold">Battery low status Threshold</label>
+                        <input type="number" name="btr-low-threshold" id="btr-low-threshold" placeholder="10" min="0" max="100" value="%BTRLOWTHRESHOLD%" style="width: 4rem;" />
                     </div>
                     <fieldset>
                         <legend>HomeKey Card Finish:</legend>
@@ -170,6 +179,7 @@
     document.getElementById("hk-always-unlock").selectedIndex = "%ALWAYSUNLOCK%";
     document.getElementById("hk-always-lock").selectedIndex = "%ALWAYSLOCK%";
     document.getElementById("web-auth-enable").selectedIndex = "%WEBENABLE%";
+    document.getElementById("prox-bat-enable").selectedIndex = "%PROXBATENABLE%";
     let form = document.getElementById("misc-config");
     async function handleForm(event) {
       event.preventDefault();

--- a/data/routes/mqtt.html
+++ b/data/routes/mqtt.html
@@ -88,6 +88,10 @@
             <label for="mqtt-tstatecmd">Lock Target State Cmd Topic</label>
             <input type="text" name="mqtt-tstatecmd" id="mqtt-tstatecmd" placeholder="topic/set_target_state" required value="%TSTATECMD%">
           </div>
+          <div style="display: flex; flex-direction: column;">
+            <label for="mqtt-btrprox-cmd-topic">SmartLock battery level Cmd Topic</label>
+            <input type="text" name="mqtt-btrprox-cmd-topic" id="mqtt-btrprox-cmd-topic" placeholder="topic/set_battery_level" required value="%BTRLEVELCMD%">
+          </div>
         </div>
       </div>
       <div class="mqtt-topics-hidden-body" data-mqtt-topics-body="1">

--- a/src/config.h
+++ b/src/config.h
@@ -60,6 +60,7 @@ enum class gpioMomentaryStateStatus : uint8_t
 #define MQTT_SET_TARGET_STATE_TOPIC "homekit/set_target_state" // MQTT Control Topic for the HomeKit lock target state
 #define MQTT_SET_CURRENT_STATE_TOPIC "homekit/set_current_state" // MQTT Control Topic for the HomeKit lock current state
 #define MQTT_STATE_TOPIC "homekit/state" // MQTT Topic for publishing the HomeKit lock target state
+#define MQTT_PROX_BAT_TOPIC "homekit/set_battery_lvl" // MQTT Topic for publishing the HomeKit lock target state
 
 // Miscellaneous
 #define HOMEKEY_COLOR TAN


### PR DESCRIPTION
### TL;DR
Added SmartLock battery level reporting functionality via MQTT and HomeKit integration.

### What changed?
- Added battery level reporting configuration options in the web UI
- Implemented battery level threshold settings (0-100%)
- Created new MQTT topic for battery level commands
- Added HomeKit battery service with low status and level characteristics
- Introduced new CLI commands for debugging purposes ('N' and 'B')

### How to test?
1. Enable SmartLock battery reporting in the Misc settings
2. Set desired battery low threshold percentage
3. Configure MQTT battery level command topic
4. Send battery level updates via MQTT or CLI commands:
   - Use 'N 0/1' to toggle battery low status
   - Use 'B [level]' to set battery percentage
5. Verify battery status appears in HomeKit
6. Confirm low battery warnings trigger when level drops below threshold

### Why make this change?
Enables monitoring of physical lock battery levels through HomeKit and MQTT, allowing users to receive notifications when batteries need replacement and maintain better awareness of their lock's power status.