### PR TITLE
Add HomeKit dumb switch mode

### DIFF
--- a/data/routes/misc.html
+++ b/data/routes/misc.html
@@ -39,6 +39,13 @@
                         </select>
                     </div>
                     <div style="display: flex;gap: 8px;">
+                        <label for="homekit-dumb-switch-mode">Dumb Switch Mode</label>
+                        <select name="homekit-dumb-switch-mode" id="homekit-dumb-switch-mode">
+                            <option value="0">Disabled</option>
+                            <option value="1">Enabled</option>
+                        </select>
+                    </div>
+                    <div style="display: flex;gap: 8px;">
                         <label for="prox-bat-enable">SmartLock battery reporting</label>
                         <select name="prox-bat-enable" id="prox-bat-enable">
                             <option value="0">Disabled</option>
@@ -180,6 +187,7 @@
     document.getElementById("hk-always-lock").selectedIndex = "%ALWAYSLOCK%";
     document.getElementById("web-auth-enable").selectedIndex = "%WEBENABLE%";
     document.getElementById("prox-bat-enable").selectedIndex = "%PROXBATENABLE%";
+    document.getElementById("homekit-dumb-switch-mode").selectedIndex = "%DUMBSWITCHMODE%";
     let form = document.getElementById("misc-config");
     async function handleForm(event) {
       event.preventDefault();


### PR DESCRIPTION
### TL;DR
Added a "Dumb Switch Mode" option for HomeKit integration that allows the lock state to update without the external interaction

### What changed?
- Added a new configuration option "Dumb Switch Mode" in the misc settings page
- Introduced `hkDumbSwitchMode` boolean flag in the misc configuration
- Modified the LockMechanism service to update the lock state immediately when in dumb switch mode

### How to test?
1. Navigate to the misc settings page
2. Enable "Dumb Switch Mode"
3. Try controlling the lock through HomeKit
4. Verify the lock state updates in HomeKit without requiring the external feedback

### Why make this change?
This change supports scenarios where users want to use the HomeKit interface without a  MQTT or GPIO interaction, essentially turning the device into a virtual switch. This change does the same thing as when using the Simple GPIO HomeKit Trigger.