### PR TITLE
Add alternate action on HomeKey success

### DIFF
--- a/data/routes/actions.html
+++ b/data/routes/actions.html
@@ -128,6 +128,26 @@
               </div>
             </fieldset>
           </div>
+          <div>
+            <fieldset>
+              <legend>Alt. action(on success)</legend>
+              <div style="display: flex;flex-direction: column;">
+                <label for="nfc-alt-action-pin">GPIO Pin</label>
+                <input type="number" name="nfc-alt-action-pin" id="nfc-alt-action-pin" placeholder="2" required value="%NFCALTACTIONPIN%" min="0" max="255">
+              </div>
+              <div style="display: flex;flex-direction: column;margin-top: .7rem;">
+                <label for="nfc-alt-action-time">Timeout (ms)</label>
+                <input type="number" name="nfc-alt-action-time" id="nfc-alt-action-time" placeholder="1000" required value="%NFCALTACTIONTIME%">
+              </div>
+              <div style="display: flex;margin-top: .7rem;gap: 8px;">
+                <label for="nfc-alt-action-hl">GPIO State</label>
+                <select name="nfc-alt-action-hl" id="nfc-alt-action-hl">
+                  <option value="0">LOW</option>
+                  <option value="1">HIGH</option>
+                </select>
+              </div>
+            </fieldset>
+          </div>
         </div>
       </div>
     </div>
@@ -201,6 +221,7 @@
   let actionMomentary = document.querySelector("#gpio-a-momentary");
   let pixelType = document.querySelector("#neo-pixel-type")
   let hkGpioState = document.querySelector("#homekey-gpio-state")
+  let hkAltActionGpioState = document.querySelector("#nfc-alt-action-hl")
   hkGpioState.selectedIndex = "%HKGPIOCONTROLSTATE%"
   pixelType.selectedIndex = "%NEOPIXELTYPE%"
   nfcshl.selectedIndex = "%NFC1HL%";
@@ -208,6 +229,7 @@
   actionlock.selectedIndex = "%GPIOALOCK%";
   actionunlock.selectedIndex = "%GPIOAUNLOCK%";
   actionMomentary.selectedIndex = "%GPIOAMOEN%";
+  hkAltActionGpioState.selectedIndex = "%NFCALTACTIONGPIOSTATE%"
   let form = document.getElementById("actions-config");
   async function handleForm(event) {
     event.preventDefault();

--- a/data/routes/misc.html
+++ b/data/routes/misc.html
@@ -8,8 +8,9 @@
                 <div style="margin-bottom: 1rem;">
                     <div id="custom-tabs" style="display: flex;justify-content: space-around;">
                         <h3 class="custom-tabs-selected-tab" style="margin: 0;width: fit-content;padding: 0.5rem;cursor: pointer;" onclick="switchTab(this)" data-tab-index="0">HomeKit</h3>
-                        <h3 style="margin: 0;width: fit-content;padding: 0.5rem;cursor: pointer;" onclick="switchTab(this)" data-tab-index="1">PN532</h3>
-                        <h3 style="margin: 0;width: fit-content;padding: 0.5rem;cursor: pointer;" onclick="switchTab(this)" data-tab-index="2">HomeSpan</h3>
+                        <h3 style="margin: 0;width: fit-content;padding: 0.5rem;cursor: pointer;" onclick="switchTab(this)" data-tab-index="1">HomeKey</h3>
+                        <h3 style="margin: 0;width: fit-content;padding: 0.5rem;cursor: pointer;" onclick="switchTab(this)" data-tab-index="2">PN532</h3>
+                        <h3 style="margin: 0;width: fit-content;padding: 0.5rem;cursor: pointer;" onclick="switchTab(this)" data-tab-index="3">HomeSpan</h3>
                     </div>
                     <span style="height: 1px;border-top: 1px #424242 solid;display: block;margin: 0;padding: 0;"></span>
                 </div>
@@ -56,6 +57,25 @@
                         <label for="btr-low-threshold">Battery low status Threshold</label>
                         <input type="number" name="btr-low-threshold" id="btr-low-threshold" placeholder="10" min="0" max="100" value="%BTRLOWTHRESHOLD%" style="width: 4rem;" />
                     </div>
+                </div>
+                <div class="custom-tabs-hidden-body" data-custom-tabs-body="1">
+                    <fieldset>
+                        <legend>Alt action Initiator Button</legend>
+                        <div style="display: flex;gap: 16px;flex-direction: column;padding: .5rem;">
+                            <div style="display: flex;gap: 8px;">
+                                <label for="hk-alt-action-init-pin">GPIO Pin</label>
+                                <input type="number" name="hk-alt-action-init-pin" id="hk-alt-action-init-pin" placeholder="255" min="0" max="100" value="%HKALTACTIONINITPIN%" style="width: 4rem;" />
+                            </div>
+                            <div style="display: flex;gap: 8px;">
+                                <label for="hk-alt-action-init-timeout">Timeout (ms)</label>
+                                <input type="number" name="hk-alt-action-init-timeout" id="hk-alt-action-init-timeout" placeholder="5000" min="0" max="10000" value="%HKALTACTIONINITTIME%" style="width: 4rem;" />
+                            </div>
+                            <div style="display: flex;gap: 8px;">
+                                <label for="hk-alt-action-led-pin">Feedback LED Pin</label>
+                                <input type="number" name="hk-alt-action-led-pin" id="hk-alt-action-led-pin" placeholder="255" min="0" max="100" value="%HKALTACTIONLEDPIN%" style="width: 4rem;" />
+                            </div>
+                        </div>
+                    </fieldset>
                     <fieldset>
                         <legend>HomeKey Card Finish:</legend>
                         <div style="display: flex;justify-content: space-evenly;margin-bottom: 0;padding-bottom: 0;">
@@ -91,7 +111,7 @@
                         </div>
                     </fieldset>
                 </div>
-                <div class="custom-tabs-hidden-body" data-custom-tabs-body="1">
+                <div class="custom-tabs-hidden-body" data-custom-tabs-body="2">
                     <div style="display: flex;flex-wrap: wrap;justify-content: center;gap: 16px;">
                         <div style="display: flex;flex-direction: column;">
                             <label for="nfc-ss-gpio-pin">SS Pin</label>
@@ -115,7 +135,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="custom-tabs-hidden-body" data-custom-tabs-body="2">
+                <div class="custom-tabs-hidden-body" data-custom-tabs-body="3">
                     <a href="https://github.com/HomeSpan/HomeSpan/blob/master/docs/GettingStarted.md#adding-a-control-button-and-status-led-optional" style="margin-bottom: 1rem;color: white;">HomeSpan Documentation</a>
                     <div>
                         <label for="ota-passwd">OTA Password</label>

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,7 +30,7 @@ lib_deps =
 	https://github.com/rednblkx/HomeSpan.git#1.9.1
 	https://github.com/rednblkx/PN532.git#b80937f4165ed3a0b1545b7bdcc892cb0bd1225b
 	https://github.com/rednblkx/HK-HomeKit-Lib.git#c916ede29bcceb9126c3d6211ce62e4d92f20095
-	https://github.com/me-no-dev/ESPAsyncWebServer.git
+	https://github.com/me-no-dev/ESPAsyncWebServer.git#079446b1c4c57cfa11d026f089813feb69d69cc5
 	https://github.com/joltwallet/esp_littlefs.git
 board_build.partitions = with_ota.csv
 extra_scripts = fs.py

--- a/src/config.h
+++ b/src/config.h
@@ -61,6 +61,7 @@ enum class gpioMomentaryStateStatus : uint8_t
 #define MQTT_SET_CURRENT_STATE_TOPIC "homekit/set_current_state" // MQTT Control Topic for the HomeKit lock current state
 #define MQTT_STATE_TOPIC "homekit/state" // MQTT Topic for publishing the HomeKit lock target state
 #define MQTT_PROX_BAT_TOPIC "homekit/set_battery_lvl" // MQTT Topic for publishing the HomeKit lock target state
+#define MQTT_HK_ALT_ACTION_TOPIC "alt_action" // MQTT Topic for publishing the Alt Action
 
 // Miscellaneous
 #define HOMEKEY_COLOR TAN
@@ -93,6 +94,12 @@ enum class gpioMomentaryStateStatus : uint8_t
 #define GPIO_ACTION_UNLOCK_STATE HIGH
 #define GPIO_ACTION_MOMENTARY_STATE static_cast<uint8_t>(gpioMomentaryStateStatus::M_DISABLED)
 #define GPIO_ACTION_MOMENTARY_TIMEOUT 5000
+#define GPIO_HK_ALT_ACTION_INIT_PIN 255
+#define GPIO_HK_ALT_ACTION_INIT_TIMEOUT 5000
+#define GPIO_HK_ALT_ACTION_INIT_LED_PIN 255
+#define GPIO_HK_ALT_ACTION_PIN 255
+#define GPIO_HK_ALT_ACTION_TIMEOUT 5000
+#define GPIO_HK_ALT_ACTION_GPIO_STATE HIGH
 
 // WebUI
 #define WEB_AUTH_ENABLED false

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1078,7 +1078,7 @@ void setupWeb() {
     const char* TAG = "mqttconfig";
     int params = request->params();
     for (int i = 0; i < params; i++) {
-      AsyncWebParameter* p = request->getParam(i);
+      const AsyncWebParameter* p = request->getParam(i);
       LOG(V, "POST[%s]: %s\n", p->name().c_str(), p->value().c_str());
       if (!strcmp(p->name().c_str(), "mqtt-broker")) {
         espConfig::mqttData.mqttBroker = p->value().c_str();
@@ -1161,7 +1161,7 @@ void setupWeb() {
     const char* TAG = "misc-config";
     int params = request->params();
     for (int i = 0; i < params; i++) {
-      AsyncWebParameter* p = request->getParam(i);
+      const AsyncWebParameter* p = request->getParam(i);
       LOG(V, "POST[%s]: %s\n", p->name().c_str(), p->value().c_str());
       if (!strcmp(p->name().c_str(), "device-name")) {
         espConfig::miscConfig.deviceName = p->value().c_str();
@@ -1274,7 +1274,7 @@ void setupWeb() {
     const char* TAG = "actions-config";
     int params = request->params();
     for (int i = 0; i < params; i++) {
-      AsyncWebParameter* p = request->getParam(i);
+      const AsyncWebParameter* p = request->getParam(i);
       LOG(V, "POST[%s]: %s\n", p->name().c_str(), p->value().c_str());
       if (!strcmp(p->name().c_str(), "nfc-neopixel-pin")) {
         if (!GPIO_IS_VALID_GPIO(p->value().toInt()) && !GPIO_IS_VALID_OUTPUT_GPIO(p->value().toInt()) && p->value().toInt() != 255) {


### PR DESCRIPTION
### TL;DR
Added support for an alternate action when using HomeKey authentication, triggered by a physical button.

### What changed?
- Added configuration options for an alternate action GPIO pin and timing
- Introduced a button-activated alternate action mode with LED feedback
- Added MQTT publishing for alternate action events
- Created new web UI fields for configuring alternate action settings
- Implemented GPIO control for alternate action output

### How to test?
1. Configure alternate action settings in the web UI:
   - Set GPIO pin for init button
   - Configure LED feedback pin (optional)
   - Set timeout values
   - Define output GPIO pin and state
2. Press and hold the configured button
3. Authenticate with HomeKey while button is held
4. Verify:
   - LED feedback (if configured)
   - GPIO output triggers
   - MQTT message publishes

### Why make this change?
Enables users to trigger an alternative action (like opening a secondary door or gate) when authenticating with HomeKey, providing more flexibility in access control scenarios. This is particularly useful in situations where a single HomeKey reader needs to control multiple outputs based on user intent.