### PR TITLE
fix(build): improve regex for deleting specific file types in CMakeLists

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -18,7 +18,7 @@ if(NOT DEFINED ENV{CI})
     WORKING_DIRECTORY ${COMPONENT_DIR}/../data 
     COMMAND bun install
     COMMAND bun run build 
-    COMMAND sh -c "find build -regex '.*\\.\\(html\\.gz\\|css\\|br\\|js\\|json\\.gz\\)' -delete"
+    COMMAND sh -c "find build \\( -name '*.html.gz' -o -name '*.css' -o -name '*.br' -o -name '*.js' -o -name '*.json.gz' \\) -delete"
     VERBATIM
   )
   littlefs_create_partition_image(spiffs ../data/build FLASH_IN_PROJECT DEPENDS webui)


### PR DESCRIPTION
This pull request updates the build process in `main/CMakeLists.txt` to improve the file deletion step during the web UI build. 
The main change is a fix to the `find` command used for cleaning up build artifacts, making it compatible with macOS find.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined web UI build configuration to improve build system clarity and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->