### PR TITLE
feat(nfc): add configurable fast polling options

### DIFF
--- a/data/src/lib/components/AppMisc.svelte
+++ b/data/src/lib/components/AppMisc.svelte
@@ -335,6 +335,17 @@
 										class="toggle toggle-primary toggle-sm"
 									/>
 								</div>
+								<div class="flex items-center justify-between py-2 px-3 bg-base-100 rounded-lg">
+									<div>
+										<p class="text-sm font-medium">Fast NFC Polling</p>
+										<p class="text-xs text-base-content/60">Reduces the delay after each PN532 poll cycle for quicker follow-up detection.</p>
+									</div>
+									<input
+										type="checkbox"
+										bind:checked={miscConfig.nfcFastPollingEnabled}
+										class="toggle toggle-primary toggle-sm"
+									/>
+								</div>
 							</div>
               <!-- HomeKey Color -->
               <div class="form-control">

--- a/data/src/lib/components/AppMisc.svelte
+++ b/data/src/lib/components/AppMisc.svelte
@@ -335,17 +335,6 @@
 										class="toggle toggle-primary toggle-sm"
 									/>
 								</div>
-								<div class="flex items-center justify-between py-2 px-3 bg-base-100 rounded-lg">
-									<div>
-										<p class="text-sm font-medium">Fast NFC Polling</p>
-										<p class="text-xs text-base-content/60">Reduces the delay after each PN532 poll cycle for quicker follow-up detection.</p>
-									</div>
-									<input
-										type="checkbox"
-										bind:checked={miscConfig.nfcFastPollingEnabled}
-										class="toggle toggle-primary toggle-sm"
-									/>
-								</div>
 							</div>
               <!-- HomeKey Color -->
               <div class="form-control">
@@ -387,6 +376,7 @@
 								ethSpiConfig={miscConfig.ethSpiConfig}
 								ethConfig={ethConfig}
 								nfcConnected={nfcConnected}
+                nfcFastPollingEnabled={miscConfig.nfcFastPollingEnabled}
 								onNfcPresetChange={handleNfcPresetChange}
 								onEthPresetChange={handleEthPresetChange}
 								onNfcPinsChange={(pins) => miscConfig.nfcGpioPins = pins}

--- a/data/src/lib/components/HardwareConfig.svelte
+++ b/data/src/lib/components/HardwareConfig.svelte
@@ -192,7 +192,7 @@
     <div class="flex items-center justify-between py-2 px-3 bg-base-200 rounded-lg">
       <div>
         <p class="text-sm font-medium">Fast NFC Polling</p>
-        <p class="text-xs text-base-content/60">Reduces the delay after each PN532 poll cycle for quicker follow-up detection.</p>
+        <p class="text-xs text-base-content/60">{"Reduces the delay (100ms -> 5ms) after each PN532 poll cycle for quicker follow-up detection."}</p>
       </div>
       <input
         type="checkbox"

--- a/data/src/lib/components/HardwareConfig.svelte
+++ b/data/src/lib/components/HardwareConfig.svelte
@@ -17,6 +17,7 @@
 		ethConfig: EthConfig | null;
 		nfcConnected?: boolean;
 		loading?: boolean;
+    nfcFastPollingEnabled: boolean;
 		onNfcPresetChange: (preset: number) => void;
 		onEthPresetChange: (preset: number) => void;
 		onNfcPinsChange: (pins: [number, number, number, number]) => void;
@@ -38,6 +39,7 @@
 		ethRmiiConfig,
 		ethSpiConfig,
 		ethConfig,
+    nfcFastPollingEnabled,
 		nfcConnected = false,
 		loading = false,
 		onNfcPresetChange,
@@ -133,7 +135,7 @@
 				<option value={255}>Custom</option>
 			</select>
 		</div>
-		<div class="grid grid-cols-4 gap-2">
+		<div class="grid grid-cols-4 gap-2 mb-2">
 			<div class="form-control">
 				<label class="label" for="nfcSsPin">
 					<span class="label-text text-xs">SS Pin</span>
@@ -187,6 +189,17 @@
 				/>
 			</div>
 		</div>
+    <div class="flex items-center justify-between py-2 px-3 bg-base-200 rounded-lg">
+      <div>
+        <p class="text-sm font-medium">Fast NFC Polling</p>
+        <p class="text-xs text-base-content/60">Reduces the delay after each PN532 poll cycle for quicker follow-up detection.</p>
+      </div>
+      <input
+        type="checkbox"
+        bind:checked={nfcFastPollingEnabled}
+        class="toggle toggle-primary toggle-sm"
+      />
+    </div>
 	</div>
 
 	<!-- Ethernet Configuration -->

--- a/data/src/lib/types/api.ts
+++ b/data/src/lib/types/api.ts
@@ -133,6 +133,8 @@ export interface MiscConfig {
   lockAlwaysLock: boolean;
   /** Enable HomeKey auth precompute cache (faster taps, higher CPU/RAM) */
   hkAuthPrecomputeEnabled: boolean;
+  /** Poll the PN532 more aggressively for faster tag detection */
+  nfcFastPollingEnabled: boolean;
   /** GPIO pin for lock control */
   controlPin: number;
   /** GPIO pin for HomeSpan status indicator */

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -195,6 +195,7 @@ This section is organized into several subsections: **HomeKit**, **HomeKey**, **
 
 *   **Performance:** Authentication optimizations.
     *   **Auth Precompute Cache:** Enable or disable precomputation of authentication context.
+    *   **Fast NFC Polling:** Reduces the delay after each PN532 polling cycle for faster follow-up detection.
 
 ### 5.3. PN532
 

--- a/main/ConfigManager.cpp
+++ b/main/ConfigManager.cpp
@@ -89,6 +89,7 @@ ConfigManager::ConfigManager() : m_isInitialized(false) {
       {"lockAlwaysUnlock", &m_miscConfig.lockAlwaysUnlock},
       {"lockAlwaysLock", &m_miscConfig.lockAlwaysLock},
       {"hkAuthPrecomputeEnabled", &m_miscConfig.hkAuthPrecomputeEnabled},
+      {"nfcFastPollingEnabled", &m_miscConfig.nfcFastPollingEnabled},
       {"controlPin", &m_miscConfig.controlPin},
       {"hsStatusPin", &m_miscConfig.hsStatusPin},
       {"webAuthEnabled", &m_miscConfig.webAuthEnabled},

--- a/main/NfcManager.cpp
+++ b/main/NfcManager.cpp
@@ -207,11 +207,16 @@ void NfcManager::authPrecomputeTask() {
  * @param readerDataManager Reference to the ReaderDataManager used to read and persist reader data.
  * @param nfcGpioPins Four GPIO pin numbers used to construct the PN532 SPI interface.
  * @param hkAuthPrecomputeEnabled If true, enables HomeKit authentication precompute behavior.
+ * @param nfcFastPollingEnabled If true, shortens the delay between polling iterations.
  */
-NfcManager::NfcManager(ReaderDataManager& readerDataManager, const std::array<uint8_t, 4> &nfcGpioPins, bool hkAuthPrecomputeEnabled)
+NfcManager::NfcManager(ReaderDataManager& readerDataManager,
+                       const std::array<uint8_t, 4> &nfcGpioPins,
+                       bool hkAuthPrecomputeEnabled,
+                       bool nfcFastPollingEnabled)
     : nfcGpioPins(nfcGpioPins),
       m_readerDataManager(readerDataManager),
       m_hkAuthPrecomputeEnabled(hkAuthPrecomputeEnabled),
+      m_nfcFastPollingEnabled(nfcFastPollingEnabled),
       m_pollingTaskHandle(nullptr),
       m_retryTaskHandle(nullptr),
       m_ecpData({ 0x6A, 0x2, 0xCB, 0x2, 0x6, 0x2, 0x11, 0x0 })
@@ -259,6 +264,7 @@ bool NfcManager::begin() {
     } else {
         ESP_LOGI(TAG, "Auth precompute disabled.");
     }
+    ESP_LOGI(TAG, "NFC fast polling: %s", m_nfcFastPollingEnabled ? "enabled" : "disabled");
     ESP_LOGI(TAG, "Starting NFC polling task...");
     xTaskCreateUniversal(pollingTaskEntry, "nfc_poll_task", 8192, this, 2, &m_pollingTaskHandle, 1);
     return true;
@@ -385,6 +391,17 @@ void NfcManager::pollingTask() {
       vTaskSuspend(NULL);
     }
 
+    const uint16_t inCommunicateThruTimeoutMs = 50;
+    const uint16_t passiveTargetTimeoutMs = 500;
+    const TickType_t pollDelayTicks =
+        pdMS_TO_TICKS(m_nfcFastPollingEnabled ? 5 : 100);
+
+    ESP_LOGI(TAG,
+             "NFC poll tuning active: delay=%lu ms, thruTimeout=%u ms, passiveTimeout=%u ms",
+             static_cast<unsigned long>(pollDelayTicks * portTICK_PERIOD_MS),
+             static_cast<unsigned int>(inCommunicateThruTimeoutMs),
+             static_cast<unsigned int>(passiveTargetTimeoutMs));
+
     while (true) {
         if (m_nfc->WriteRegister({0x63,0x3d,0x0}) != pn532::SUCCESS) {
             ESP_LOGE(TAG, "PN532 is unresponsive. Attempting to reconnect...");
@@ -397,12 +414,12 @@ void NfcManager::pollingTask() {
         }
 
         std::vector<uint8_t> res;
-        m_nfc->InCommunicateThru(std::vector<uint8_t>(m_ecpData.begin(), m_ecpData.end()), res, 50);
+        m_nfc->InCommunicateThru(std::vector<uint8_t>(m_ecpData.begin(), m_ecpData.end()), res, inCommunicateThruTimeoutMs);
 
         std::vector<uint8_t> uid;
         std::array<uint8_t,2> sens_res;
         uint8_t sel_res;
-        pn532::Status passiveTargetFound = m_nfc->InListPassiveTarget(PN532_MIFARE_ISO14443A, uid, sens_res, sel_res, 500);
+        pn532::Status passiveTargetFound = m_nfc->InListPassiveTarget(PN532_MIFARE_ISO14443A, uid, sens_res, sel_res, passiveTargetTimeoutMs);
         
         if (passiveTargetFound == pn532::SUCCESS) {
             ESP_LOGI(TAG, "NFC tag detected!");
@@ -416,7 +433,7 @@ void NfcManager::pollingTask() {
             m_nfc->setPassiveActivationRetries(0);
         }
 
-        vTaskDelay(pdMS_TO_TICKS(100));
+        vTaskDelay(pollDelayTicks);
         taskYIELD();
     }
 }

--- a/main/include/NfcManager.hpp
+++ b/main/include/NfcManager.hpp
@@ -19,7 +19,10 @@ namespace espConfig { struct misc_config_t; }
 
 class NfcManager {
 public:
-    NfcManager(ReaderDataManager& readerDataManager, const std::array<uint8_t, 4> &nfcGpioPins, bool hkAuthPrecomputeEnabled);
+    NfcManager(ReaderDataManager& readerDataManager,
+               const std::array<uint8_t, 4> &nfcGpioPins,
+               bool hkAuthPrecomputeEnabled,
+               bool nfcFastPollingEnabled);
     /**
  * @brief Unsubscribes the manager's HomeKey event subscription from the global EventBus.
  *
@@ -69,6 +72,7 @@ private:
 
     ReaderDataManager& m_readerDataManager;
     const bool m_hkAuthPrecomputeEnabled;
+    const bool m_nfcFastPollingEnabled;
 
     TaskHandle_t m_pollingTaskHandle;
     TaskHandle_t m_retryTaskHandle;

--- a/main/include/config.hpp
+++ b/main/include/config.hpp
@@ -145,6 +145,7 @@ namespace espConfig
     bool lockAlwaysUnlock = HOMEKEY_ALWAYS_UNLOCK;
     bool lockAlwaysLock = HOMEKEY_ALWAYS_LOCK;
     bool hkAuthPrecomputeEnabled = HK_AUTH_PRECOMPUTE_ENABLED;
+    bool nfcFastPollingEnabled = NFC_FAST_POLLING_ENABLED;
     uint8_t controlPin = HS_PIN;
     uint8_t hsStatusPin = HS_STATUS_LED;
     bool webAuthEnabled = WEB_AUTH_ENABLED;

--- a/main/include/defaults.h
+++ b/main/include/defaults.h
@@ -55,6 +55,7 @@
 #define HOMEKEY_ALWAYS_UNLOCK 0 // Flag indicating if a successful Homekey authentication should always set and publish the unlock state
 #define HOMEKEY_ALWAYS_LOCK 0  // Flag indicating if a successful Homekey authentication should always set and publish the lock state
 #define HK_AUTH_PRECOMPUTE_ENABLED true // Enable HomeKey auth precompute cache (faster taps, higher CPU/RAM)
+#define NFC_FAST_POLLING_ENABLED false // Poll the PN532 more aggressively for faster tag detection
 #define HS_STATUS_LED 255 // HomeSpan Status LED GPIO pin
 #define HS_PIN 255 // GPIO Pin for a Configuration Mode button (more info on https://github.com/HomeSpan/HomeSpan/blob/master/docs/UserGuide.md#device-configuration-mode)
 #define BTR_PROX_BAT_ENABLED false // Enable or disable battery monitoring

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -161,7 +161,8 @@ void setup() {
   nfc_init:
     nfcManager = std::make_unique<NfcManager>(*readerDataManager,
                                 miscConfig.nfcPinsPreset == PIN_UNSET ? miscConfig.nfcGpioPins : nfcGpioPinsPresets[miscConfig.nfcPinsPreset].gpioPins,
-                                miscConfig.hkAuthPrecomputeEnabled);
+                                miscConfig.hkAuthPrecomputeEnabled,
+                                miscConfig.nfcFastPollingEnabled);
     nfcManager->begin();
   }
   webServerManager->setNfcManager(nfcManager.get());


### PR DESCRIPTION
## Summary

Adds a new **Fast NFC Polling** option in the misc settings.

When enabled, the delay after each PN532 poll cycle is reduced from `100ms` to `5ms`. The default stays disabled, so existing setups keep the same behavior unless the option is turned on.

I added this because NFC detection was noticeably slower on my setup before. With this option enabled, taps are detected much faster.

## Changes

- Adds the new config/default value
- Wires it through `ConfigManager`
- Uses it in `NfcManager` polling
- Adds the toggle to the web UI
- Updates the configuration docs

## Testing

- `cd data && bun run build` passes
- Tested on my PN532 setup, tap detection is much quicker with Fast NFC Polling enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Fast NFC Polling" configuration option that reduces inter-cycle delays in NFC polling operations to enable faster tag detection. Available as a hardware configuration toggle, disabled by default.

* **Documentation**
  * Updated configuration documentation to describe the Fast NFC Polling setting and its performance implications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->