### PR TITLE
fix(lock): restart momentary timer after state override

### DIFF
--- a/main/LockManager.cpp
+++ b/main/LockManager.cpp
@@ -7,17 +7,6 @@
 
 const char* LockManager::TAG = "LockManager";
 
-static uint8_t sourceToMomentaryMask(LockManager::Source source) {
-    switch (source) {
-        case LockManager::HOMEKIT:
-            return static_cast<uint8_t>(gpioMomentaryStateStatus::M_HOME);
-        case LockManager::NFC:
-            return static_cast<uint8_t>(gpioMomentaryStateStatus::M_HK);
-        default:
-            return 0;
-    }
-}
-
 /**
  * @brief Initialize a LockManager with configuration and wire its event handlers.
  *
@@ -145,7 +134,18 @@ void LockManager::startMomentaryTimerIfNeeded(Source source) {
                                 !m_actionsConfig.hkDumbSwitchMode)
                                    ? 0
                                    : m_actionsConfig.gpioActionMomentaryEnabled;
-    bool isMomentarySource = ((sourceToMomentaryMask(source) & momentarySources) != 0);
+    uint8_t sourceMask = 0;                                   
+    switch (source) {
+      case LockManager::HOMEKIT:
+          sourceMask = static_cast<uint8_t>(gpioMomentaryStateStatus::M_HOME);
+          break;
+      case LockManager::NFC:
+          sourceMask = static_cast<uint8_t>(gpioMomentaryStateStatus::M_HK);
+          break;
+      default:
+          break;
+    }
+    bool isMomentarySource = ((sourceMask & momentarySources) != 0);
 
     if (m_targetState == lockStates::UNLOCKED && isMomentarySource) {
         if (!momentaryStateTimer) {

--- a/main/LockManager.cpp
+++ b/main/LockManager.cpp
@@ -7,6 +7,16 @@
 
 const char* LockManager::TAG = "LockManager";
 
+static uint8_t sourceToMomentaryMask(LockManager::Source source) {
+    switch (source) {
+        case LockManager::HOMEKIT:
+            return static_cast<uint8_t>(gpioMomentaryStateStatus::M_HOME);
+        case LockManager::NFC:
+            return static_cast<uint8_t>(gpioMomentaryStateStatus::M_HK);
+        default:
+            return 0;
+    }
+}
 
 /**
  * @brief Initialize a LockManager with configuration and wire its event handlers.
@@ -31,8 +41,8 @@ LockManager::LockManager(const espConfig::misc_config_t& miscConfig, const espCo
       std::error_code ec;
       EventLockState s = alpaca::deserialize<EventLockState>(payload, ec);
       if(ec) { ESP_LOGE(TAG, "Failed to deserialize override state event: %s", ec.message().c_str()); return; }
-      ESP_LOGD(TAG, "Received override state event: %d -> %d", s.currentState, s.targetState);
-      overrideState(s.currentState, s.targetState);
+      ESP_LOGD(TAG, "Received override state event: %d -> %d from source %d", s.currentState, s.targetState, s.source);
+      overrideState(s.currentState, s.targetState, Source(s.source));
     });
   m_target_state_event = AppEventLoop::subscribe(LOCK_EVENT, LOCK_TARGET_STATE_CHANGED, [&](const uint8_t* data, size_t size){
       if(size == 0 || data == nullptr) return;
@@ -123,6 +133,39 @@ void LockManager::handleTimer(void* instance){
   static_cast<LockManager*>(instance)->setTargetState(LOCKED, INTERNAL);
 }
 
+void LockManager::stopMomentaryTimer() {
+    if (momentaryStateTimer && esp_timer_is_active(momentaryStateTimer)) {
+        esp_timer_stop(momentaryStateTimer);
+    }
+}
+
+void LockManager::startMomentaryTimerIfNeeded(Source source) {
+    uint8_t momentarySources = (((m_actionsConfig.gpioActionMomentaryEnabled |
+                                  m_actionsConfig.gpioActionPin) == 255) &
+                                !m_actionsConfig.hkDumbSwitchMode)
+                                   ? 0
+                                   : m_actionsConfig.gpioActionMomentaryEnabled;
+    bool isMomentarySource = ((sourceToMomentaryMask(source) & momentarySources) != 0);
+
+    if (m_targetState == lockStates::UNLOCKED && isMomentarySource) {
+        if (!momentaryStateTimer) {
+            ESP_LOGE(TAG, "Cannot start momentary unlock timer: timer was not created.");
+            return;
+        }
+        if (esp_timer_is_active(momentaryStateTimer)) {
+            return;
+        }
+        ESP_LOGI(TAG,
+                 "Starting momentary unlock timer for %d ms from source %d.",
+                 m_actionsConfig.gpioActionMomentaryTimeout,
+                 static_cast<int>(source));
+        esp_err_t err = esp_timer_start_once(momentaryStateTimer, m_actionsConfig.gpioActionMomentaryTimeout * 1000);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to start momentary unlock timer: %s", esp_err_to_name(err));
+        }
+    }
+}
+
 /**
  * @brief Gets the current lock state.
  *
@@ -162,7 +205,7 @@ void LockManager::setTargetState(uint8_t state, Source source) {
 
     ESP_LOGI(TAG, "Setting target state to %d (c:%d,t:%d), from source %d", state, m_currentState, m_targetState, static_cast<int>(source));
 
-    if(esp_timer_is_active(momentaryStateTimer)) esp_timer_stop(momentaryStateTimer);
+    stopMomentaryTimer();
 
     m_targetState = state;
 
@@ -184,38 +227,34 @@ void LockManager::setTargetState(uint8_t state, Source source) {
     }
     AppEventLoop::publish(LOCK_EVENT, LOCK_STATE_CHANGED, d.data(), d_len);
 
-    uint8_t momentarySources = (((m_actionsConfig.gpioActionMomentaryEnabled |
-                                  m_actionsConfig.gpioActionPin) == 255) &
-                                !m_actionsConfig.hkDumbSwitchMode)
-                                   ? 0
-                                   : m_actionsConfig.gpioActionMomentaryEnabled;
-    bool isMomentarySource = ((static_cast<uint8_t>(source) & momentarySources) != 0);
-
-    if (m_targetState == lockStates::UNLOCKED && isMomentarySource) {
-        ESP_LOGI(TAG, "Starting momentary unlock timer for %d ms.", m_actionsConfig.gpioActionMomentaryTimeout);
-        esp_timer_start_once(momentaryStateTimer, m_actionsConfig.gpioActionMomentaryTimeout * 1000);
-    }
+    startMomentaryTimerIfNeeded(source);
 }
 
 /**
  * @brief Apply an external override to the lock's current and/or target state and notify observers.
  *
  * If a provided state equals 255, that state is left unchanged. Stops any active momentary-state timer,
- * updates the internal current and target states, and publishes the resulting state to "lock/action"
- * and "lock/stateChanged".
+ * updates the internal current and target states, publishes the resulting state to "lock/action"
+ * and "lock/stateChanged", and restarts momentary timing when the override requests an unlocked
+ * state from a configured momentary source.
  *
  * @param c_state External current state to apply, or 255 to leave the current state unchanged.
  * @param t_state External target state to apply, or 255 to leave the target state unchanged.
+ * @param source Origin of the override, used for momentary timer decisions.
  */
-void LockManager::overrideState(uint8_t c_state, uint8_t t_state) {
-    if (c_state == m_currentState && t_state == m_targetState) return;
+void LockManager::overrideState(uint8_t c_state, uint8_t t_state, Source source) {
+    if (c_state == m_currentState && t_state == m_targetState) {
+        stopMomentaryTimer();
+        startMomentaryTimerIfNeeded(source);
+        return;
+    }
 
-    ESP_LOGI(TAG, "External source reported new c_state: %d t_state: %d. Overriding internal state.", c_state, t_state);
+    ESP_LOGI(TAG, "External source %d reported new c_state: %d t_state: %d. Overriding internal state.", static_cast<int>(source), c_state, t_state);
 
     m_currentState = c_state != lockStates::MAX ? c_state : m_currentState;
     m_targetState = t_state != lockStates::MAX ? t_state : m_targetState;
 
-    if(momentaryStateTimer && esp_timer_is_active(momentaryStateTimer)) esp_timer_stop(momentaryStateTimer);
+    stopMomentaryTimer();
     EventLockState s{
       .currentState = static_cast<uint8_t>(m_currentState),
       .targetState = static_cast<uint8_t>(m_targetState),
@@ -225,4 +264,5 @@ void LockManager::overrideState(uint8_t c_state, uint8_t t_state) {
     size_t d_len = alpaca::serialize(s, d);
     AppEventLoop::publish(HW_EVENT, HW_ACTION, d.data(), d_len);
     AppEventLoop::publish(LOCK_EVENT, LOCK_STATE_CHANGED, d.data(), d_len);
+    startMomentaryTimerIfNeeded(source);
 }

--- a/main/include/LockManager.hpp
+++ b/main/include/LockManager.hpp
@@ -76,12 +76,12 @@ public:
 
     /**
      * @brief Forces the manager's internal state to match an external report.
-     * This method updates the state WITHOUT triggering a physical action.
-     * Useful for syncing with external state changes reported via MQTT.
+     * Useful for syncing with external state changes reported via MQTT or HomeKit.
      * @param state The new current state
      * @param tstate The new target state
+     * @param source The origin of the override.
      */
-    void overrideState(uint8_t cstate, uint8_t tstate);
+    void overrideState(uint8_t cstate, uint8_t tstate, Source source);
 private:
     const espConfig::misc_config_t& m_miscConfig;
     const espConfig::actions_config_t& m_actionsConfig;
@@ -97,4 +97,6 @@ private:
 
     static const char* TAG;
     static void handleTimer(void* instance);
+    void stopMomentaryTimer();
+    void startMomentaryTimerIfNeeded(Source source);
 };


### PR DESCRIPTION
## Summary

Fixes an issue where a lock could stay unlocked after a restart if it was restarted while already in the unlocked state.

When the device restored or received an override state with the current/target state still unlocked, the existing momentary timer was no longer running and was not started again. Because of that, momentary unlock behavior did not complete after restart and the lock could remain unlocked instead of returning to locked after the configured timeout.

This change makes `LockManager` restart the momentary timer when an unlocked override state comes from a configured momentary source.

## Changes

- Passes the override event source into `LockManager::overrideState()`
- Adds shared helper logic for stopping and starting the momentary timer
- Reuses the same momentary timer decision logic for normal target changes and override state updates
- Starts the momentary timer again when an override reports an unlocked target state from a momentary source
- Handles the case where the override state matches the existing state but the timer still needs to be restarted

## Testing

- Tested on my lock setup
- Restarted the device while the lock was unlocked
- Verified that the momentary timer starts again and the lock returns to locked after the configured timeout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized momentary-unlock timer lifecycle for more reliable stop/start behavior during state changes and overrides; ensures timers are stopped before state changes and conditionally restarted based on command origin.

* **Documentation**
  * Updated docs to record command-origin tracking for overrides and to surface origin and state values in override logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->