### PR TITLE
fix(webui): propagate fast NFC polling toggle changes

### DIFF
--- a/data/src/lib/components/AppMisc.svelte
+++ b/data/src/lib/components/AppMisc.svelte
@@ -380,6 +380,7 @@
 								onNfcPresetChange={handleNfcPresetChange}
 								onEthPresetChange={handleEthPresetChange}
 								onNfcPinsChange={(pins) => miscConfig.nfcGpioPins = pins}
+								onNfcFastPollingToggle={(enabled) => miscConfig.nfcFastPollingEnabled = enabled}
 								onEthernetToggle={(enabled) => miscConfig.ethernetEnabled = enabled}
 								onEthPhyTypeChange={(phyType) => miscConfig.ethPhyType = phyType}
 								onEthSpiBusChange={(bus) => miscConfig.ethSpiBus = bus}

--- a/data/src/lib/components/HardwareConfig.svelte
+++ b/data/src/lib/components/HardwareConfig.svelte
@@ -21,6 +21,7 @@
 		onNfcPresetChange: (preset: number) => void;
 		onEthPresetChange: (preset: number) => void;
 		onNfcPinsChange: (pins: [number, number, number, number]) => void;
+		onNfcFastPollingToggle: (enabled: boolean) => void;
 		onEthernetToggle: (enabled: boolean) => void;
 		onEthPhyTypeChange: (phyType: number) => void;
 		onEthSpiBusChange: (bus: number) => void;
@@ -45,6 +46,7 @@
 		onNfcPresetChange,
 		onEthPresetChange,
 		onNfcPinsChange,
+		onNfcFastPollingToggle,
 		onEthernetToggle,
 		onEthPhyTypeChange,
 		onEthSpiBusChange,
@@ -196,7 +198,8 @@
       </div>
       <input
         type="checkbox"
-        bind:checked={nfcFastPollingEnabled}
+        checked={nfcFastPollingEnabled}
+        onchange={(e) => onNfcFastPollingToggle((e.target as HTMLInputElement).checked)}
         class="toggle toggle-primary toggle-sm"
       />
     </div>


### PR DESCRIPTION
## Summary

Fixes the Fast NFC Polling toggle in the Web UI.

Previously, changing the toggle only updated local state inside `HardwareConfig.svelte`. The parent `miscConfig.nfcFastPollingEnabled` value was not updated, so saving the misc config produced an empty diff and sent `{}` to `/config/save?type=misc`.

This caused the API to return:

```text
Received empty object, nothing to save

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added NFC fast polling toggle control to hardware configuration settings, allowing users to enable or disable fast NFC polling mode.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rednblkx/HomeKey-ESP32/pull/277)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->