### PR TITLE
fix: reliable startup on headless (5V PSU, no USB) boot

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,3 +1,16 @@
+menu "HomeKey Setup AP"
+
+    config HOMEKEY_AP_PASSWORD
+        string "WiFi AP setup password (min 8 chars, WPA2/WPA3)"
+        default "changeme1"
+        help
+            Password for the temporary setup WiFi AP that is started when no
+            WiFi credentials are configured.  Change this before first flash.
+            The AP is only active until credentials are saved via the captive
+            portal and the device reboots.
+
+endmenu
+
 menu "Arduino Console USB-JTAG"
   config ARDUINO_USE_USB_JTAG
     depends on !IDF_TARGET_ESP32

--- a/main/WebServerManager.cpp
+++ b/main/WebServerManager.cpp
@@ -139,7 +139,7 @@ void WebServerManager::begin() {
   bool isApMode = (wifiErr == ESP_OK && (currentMode == WIFI_MODE_AP || currentMode == WIFI_MODE_APSTA));
   bool isHttpsEnabled = m_configManager.getConfig<espConfig::misc_config_t>().webHttpsEnabled;
   httpd_ssl_config_t ssl_config = HTTPD_SSL_CONFIG_DEFAULT();
-  ssl_config.httpd.max_uri_handlers = 22;
+  ssl_config.httpd.max_uri_handlers = 32;
   ssl_config.httpd.max_open_sockets = 4;
   ssl_config.httpd.stack_size = 6144;
   ssl_config.httpd.uri_match_fn = httpd_uri_match_wildcard;
@@ -1863,7 +1863,7 @@ void WebServerManager::broadcastWs(const uint8_t *payload, size_t len,
     for (const auto &c : m_wsClients)
       fds.push_back(c->fd);
   }
-  static const size_t max_buffer = 64;
+  static const size_t max_buffer = 512;
   if (fds.empty()) {
     if(m_wsBroadcastBuffer.size() >= max_buffer){
       m_wsBroadcastBuffer.pop_front();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -23,6 +23,7 @@
 #include "loggable_espidf.hpp"
 #include "WebSocketLogSinker.h"
 #include "lwip/inet.h"
+#include <esp_wifi.h>
 
 std::unique_ptr<LockManager> lockManager;
 std::unique_ptr<ReaderDataManager> readerDataManager;
@@ -36,6 +37,17 @@ std::unique_ptr<NfcManager> nfcManager;
 static dns_server_handle_t dns_server = NULL;
 
 bool pollHS = false;
+
+static bool webStarted = false;
+
+static void startWebServer() {
+  if (webStarted) return;
+  webStarted = true;
+  char identifier[18];
+  sprintf(identifier, "%.2s%.2s%.2s%.2s%.2s%.2s", HAPClient::accessory.ID, HAPClient::accessory.ID + 3, HAPClient::accessory.ID + 6, HAPClient::accessory.ID + 9, HAPClient::accessory.ID + 12, HAPClient::accessory.ID + 15);
+  mqttManager->begin(std::string(identifier));
+  webServerManager->begin();
+}
 
 static void dhcp_set_captiveportal_url(void) {
     esp_netif_ip_info_t ip_info;
@@ -66,21 +78,22 @@ static void start_captive_portal(void)
 
 std::function<void(int)> lambda = [](int status) {
   if (status == 1) {
-    char identifier[18];
-    sprintf(identifier, "%.2s%.2s%.2s%.2s%.2s%.2s", HAPClient::accessory.ID, HAPClient::accessory.ID + 3, HAPClient::accessory.ID + 6, HAPClient::accessory.ID + 9, HAPClient::accessory.ID + 12, HAPClient::accessory.ID + 15);
-    mqttManager->begin(std::string(identifier));
-    webServerManager->begin(); 
+    startWebServer();
   } else if (status == 0){
     pollHS = false;
     mqttManager->end();
     webServerManager->end();
     WiFi.mode(WIFI_AP_STA);
-    WiFi.softAP("HomeKey-ESP32", "homekey123", 11, false, 2, false, WIFI_AUTH_WPA2_WPA3_PSK, WIFI_CIPHER_TYPE_AES_CMAC128); 
+    // SSID includes last 3 MAC bytes to avoid collisions; password set via menuconfig
+    uint8_t mac[6];
+    esp_read_mac(mac, ESP_MAC_BT);
+    char apSsid[24];
+    snprintf(apSsid, sizeof(apSsid), "HK-Setup-%02X%02X%02X", mac[3], mac[4], mac[5]);
+    WiFi.softAP(apSsid, CONFIG_HOMEKEY_AP_PASSWORD, 11, false, 2, false, WIFI_AUTH_WPA2_WPA3_PSK, WIFI_CIPHER_TYPE_AES_CMAC128);
     start_captive_portal();
     webServerManager->begin();
-    while(true){
-      vTaskDelay(pdMS_TO_TICKS(100));
-    }
+    // Return immediately — do not block setup(). HAP starts after WiFi credentials are
+    // saved via captive portal and device reboots.
   }
 };
 using namespace loggable;
@@ -98,6 +111,27 @@ using namespace loggable;
  *       GPIO pin configuration based on persisted settings.
  */
 void setup() {
+  gpio_set_pull_mode(GPIO_NUM_3, GPIO_PULLUP_ONLY);  // UART0 RX idle-HIGH without CH340
+
+  // Read stored WiFi credentials from arduino-esp32 NVS before turning off WiFi.
+  // Used to bridge into HomeSpan's wifiNVS if it was never populated (e.g. captive-portal
+  // session was interrupted before homeSpan.setWifiCredentials() could be called).
+  char bridgeSSID[33] = {0};
+  char bridgePSK[65] = {0};
+  WiFi.mode(WIFI_STA);  // ensure WiFi driver is initialised so esp_wifi_get_config() works
+  {
+    wifi_config_t wifiStaCfg = {};
+    if (esp_wifi_get_config(WIFI_IF_STA, &wifiStaCfg) == ESP_OK && strlen((char*)wifiStaCfg.sta.ssid) > 0) {
+      strncpy(bridgeSSID, (char*)wifiStaCfg.sta.ssid, 32);
+      strncpy(bridgePSK, (char*)wifiStaCfg.sta.password, 64);
+    }
+  }
+
+  // Stop WiFi entirely so any in-progress auto-connect from NVS is cancelled before HomeSpan
+  // registers its GOT_IP handler. HomeSpan.begin() will re-enable WiFi through its own init.
+  WiFi.disconnect(true);    // disconnect + turn off WiFi module
+  WiFi.mode(WIFI_OFF);
+  vTaskDelay(pdMS_TO_TICKS(100));
   Serial.begin(115200);
   loggable::espidf::LogHook::install(false, true);
   Sinker::instance().add_sinker(std::make_shared<loggable::ConsoleLogSinker>());
@@ -176,6 +210,15 @@ void setup() {
   webServerManager->setNfcManager(nfcManager.get());
   webServerManager->setMqttManager(mqttManager.get());
   hardwareManager->begin();
+
+  // Bridge arduino WiFi credentials into HomeSpan's wifiNVS if HomeSpan has none.
+  // homeSpan.begin() (inside homekitLock->begin()) writes the struct to NVS and skips
+  // AP mode when the struct is populated — so we must seed it BEFORE begin().
+  if (strlen(bridgeSSID) > 0) {
+    homeSpan.setWifiCredentials(bridgeSSID, bridgePSK);
+    ESP_LOGI("Main", "Seeded HomeSpan WiFi from arduino NVS: %s", bridgeSSID);
+  }
+
   homekitLock->begin();
   lockManager->begin();
   WiFi.onEvent([](arduino_event_id_t event){
@@ -187,6 +230,26 @@ void setup() {
       count++;
     }
   }, ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
+
+  // Fallback: start webserver + re-enable HAP polling if HomeSpan missed GOT_IP (headless boot)
+  WiFi.onEvent([](arduino_event_id_t event, arduino_event_info_t info){
+    startWebServer();
+    pollHS = true;
+  }, ARDUINO_EVENT_WIFI_STA_GOT_IP);
+
+  // Watchdog: restart if WiFi never connects within 90s of boot.
+  // Skip restart in AP/APSTA mode — device is awaiting credentials via captive portal.
+  xTaskCreate([](void*) {
+    vTaskDelay(pdMS_TO_TICKS(90000));
+    wifi_mode_t wdMode = WIFI_MODE_NULL;
+    esp_wifi_get_mode(&wdMode);
+    if (wdMode == WIFI_MODE_STA && !WiFi.isConnected()) {
+      ESP_LOGI("WiFiWatchdog", "No WiFi after 90s in STA mode — restarting");
+      esp_restart();
+    }
+    vTaskDelete(nullptr);
+  }, "wifi_wd", 2048, nullptr, 1, nullptr);
+
   pollHS = true;
 }
 


### PR DESCRIPTION
## Problem

When the ESP32 is powered from a 5V supply **without a USB cable**, the web server and MQTT never start after WiFi connects. The device is reachable by ping but the web UI is unreachable indefinitely. This is a production-only bug — USB users don't see it because `Serial.begin()` absorbs enough time to mask the race.

**Root cause:** arduino-esp32 auto-connects using NVS credentials before `setup()` runs. HomeSpan registers its `GOT_IP` handler inside `homeSpan.begin()`, which is called later. On a headless boot WiFi connects in ~200 ms, reliably before `homeSpan.begin()` is reached. The `GOT_IP` event is lost, `webServerManager->begin()` is never called.

Two secondary issues found during debugging:
- If the captive-portal session was interrupted before reboot, HomeSpan's NVS is empty while arduino-esp32's NVS has valid credentials → device loops in AP mode forever.
- The existing AP callback (`status == 0`) blocked `loop()` with `while(true)`, freezing HAP event processing permanently.

## Changes

**`main/main.cpp`**
- Call `WiFi.disconnect(true)` + `WiFi.mode(WIFI_OFF)` at the very top of `setup()` before `Serial.begin()`. This cancels any in-progress auto-connect so HomeSpan can register its `GOT_IP` handler before WiFi reconnects.
- Read arduino-esp32 NVS credentials before shutting WiFi off, then call `homeSpan.setWifiCredentials()` before `homeSpan.begin()`. Bridges the edge case where HomeSpan's NVS was never written (interrupted captive-portal session).
- Extract `startWebServer()` with a `webStarted` guard. Both the HomeSpan callback and a new independent `ARDUINO_EVENT_WIFI_STA_GOT_IP` handler call it — whichever fires first wins, the other is a no-op.
- Remove `while(true)` from the AP callback so `loop()` keeps running.
- Derive AP SSID from BT MAC bytes (`HK-Setup-XXYYZZ`) to avoid collisions.
- Add 90s watchdog: restart if WiFi never connects in STA mode (skips restart in AP/APSTA mode to not interrupt a captive-portal session).
- `gpio_set_pull_mode(GPIO_NUM_3, GPIO_PULLUP_ONLY)` as first line: keeps UART0 RX high without CH340 powered, preventing spurious serial input on headless boards.

**`main/WebServerManager.cpp`**
- `max_uri_handlers` 22 → 32: was silently dropping route registrations when the table was full.
- Pre-connection WebSocket broadcast buffer 64 → 512: retains boot log messages until the first browser connects.

**`main/Kconfig.projbuild`**
- Add `CONFIG_HOMEKEY_AP_PASSWORD` (default `"changeme1"`) so the setup AP password is configurable via menuconfig instead of hardcoded.

**`components/HomeSpan/upstream` (submodule)**
- `networkEventQueue` size 10 → 30: prevents overflow of burst events on headless boot.
- `if (xQueueReceive(...))` → `while (xQueueReceive(...))`: drain all queued events per `poll()` call instead of one per `loop()` iteration.

## Testing

Tested on ESP32 WROOM NodeMCU (CH340), 5V 3A PSU via Vin, no USB cable attached, ESP-IDF v5.5.4, arduino-esp32 3.3.8. Web UI, MQTT, and HomeKit all start reliably on every boot.

Full technical write-up: [`docs/upstream-pr-wifi-headless.md`](https://github.com/MadeInHelpup/HomeKey-ESP32-1wire-lox/blob/main/docs/upstream-pr-wifi-headless.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WiFi setup AP mode now activates with MAC-derived SSID when no credentials are configured
  * Captive portal added for credential entry during initial setup
  * HomeKey Setup AP password configuration option added

* **Improvements**
  * Device automatically restarts if WiFi connection fails after 90 seconds
  * Web server capacity enhanced to support more concurrent connections and broadcast frames

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rednblkx/HomeKey-ESP32/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->