### PR TITLE
feat: impl simple gpio pin allocator

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(SRCS "main.cpp" "app_events.cpp" "app_event_loop.cpp" "ConfigManager.cpp" "ReaderDataManager.cpp"
                     "HardwareManager.cpp" "HomeKitLock.cpp" "LockManager.cpp"
                     "MqttManager.cpp" "HKServices.cpp" "NfcManager.cpp" "Pn532Reader.cpp" "Pn7160Reader.cpp" "WebServerManager.cpp" "WebSocketLogSinker.cpp"
-                    "ConsoleLogSinker.cpp"
+                    "ConsoleLogSinker.cpp" "GPIOAllocator.cpp"
                     INCLUDE_DIRS "include"
                     PRIV_REQUIRES HomeSpan pn532_hal pn7160 DigitalDoorKey esp_https_server mqtt libsodium
                     msgpack-c json loggable loggable_espidf esp_wifi dns_server)

--- a/main/GPIOAllocator.cpp
+++ b/main/GPIOAllocator.cpp
@@ -1,0 +1,3 @@
+#include "GPIOAllocator.hpp"
+std::mutex GPIOAllocator::mutex_;
+std::array<std::string, GPIO_NUM_MAX> GPIOAllocator::owners_;

--- a/main/HardwareManager.cpp
+++ b/main/HardwareManager.cpp
@@ -2,8 +2,11 @@
 #include "LockManager.hpp"
 #include "Pixel.h"
 #include "config.hpp"
+#include "driver/gpio.h"
 #include "esp_timer.h"
 #include "eventStructs.hpp"
+#include "hal/gpio_types.h"
+#include "soc/gpio_num.h"
 
 const char* HardwareManager::TAG = "HardwareManager";
 
@@ -30,6 +33,27 @@ HardwareManager::HardwareManager(const espConfig::actions_config_t& miscConfig)
       m_lockControlTaskHandle(nullptr),
       m_lockControlQueue(nullptr)
 {
+  pinAllocations.emplace(PinFunctions::ACTION,
+      GPIOAllocator::instance().acquire(gpio_num_t(miscConfig.gpioActionPin), GPIO_MODE_OUTPUT, "ACTION_PIN"));
+  pinAllocations.emplace(PinFunctions::SUCCESS,
+      GPIOAllocator::instance().acquire(gpio_num_t(miscConfig.nfcSuccessPin), GPIO_MODE_OUTPUT, "SUCCESS_AUTH"));
+  pinAllocations.emplace(PinFunctions::FAIL,
+      GPIOAllocator::instance().acquire(gpio_num_t(miscConfig.nfcFailPin), GPIO_MODE_OUTPUT, "FAIL_AUTH"));
+  pinAllocations.emplace(PinFunctions::PIXEL,
+      GPIOAllocator::instance().acquire(gpio_num_t(miscConfig.nfcNeopixelPin), GPIO_MODE_OUTPUT, "NEOPIXEL_PIN"));
+  pinAllocations.emplace(PinFunctions::ALT_ACTION,
+      GPIOAllocator::instance().acquire(gpio_num_t(miscConfig.hkAltActionPin), GPIO_MODE_OUTPUT, "ALT_ACTION"));
+  pinAllocations.emplace(PinFunctions::ALT_ACTION_LED,
+      GPIOAllocator::instance().acquire(gpio_num_t(miscConfig.hkAltActionInitLedPin), GPIO_MODE_OUTPUT, "ALT_ACTION_LED"));
+  pinAllocations.emplace(PinFunctions::ALT_ACTION_INIT,
+      GPIOAllocator::instance().acquire(gpio_num_t(miscConfig.hkAltActionInitPin), GPIO_MODE_INPUT, "INIT_ALT_ACTION"));
+  pinAllocations.emplace(PinFunctions::TAG_EVENT,
+      GPIOAllocator::instance().acquire(gpio_num_t(miscConfig.tagEventPin), GPIO_MODE_OUTPUT, "TAG_EVENT_PIN"));
+  for(auto &p : pinAllocations){
+    if(!p.second.has_value()){
+      ESP_LOGW(TAG, "Could not acquire GPIO Pin for '%d' with error '%d'", p.first, p.second.error());
+    }
+  }
   m_hardware_action_event = AppEventLoop::subscribe(HW_EVENT, HW_ACTION, [&](const uint8_t* data, size_t size){
     if(size == 0 || data == nullptr) return;
     std::span<const uint8_t> payload(data, size);
@@ -39,27 +63,95 @@ HardwareManager::HardwareManager(const espConfig::actions_config_t& miscConfig)
     ESP_LOGD(TAG, "Received action event: %d -> %d", s.currentState, s.targetState);
     setLockOutput(s.targetState);
   });
-  m_gpio_pin_event = AppEventLoop::subscribe(HW_EVENT, HW_CONFIG_CHANGED, [&](const uint8_t* data, size_t size){
-    if(size == 0 || data == nullptr) return;
+  m_gpio_pin_event = AppEventLoop::subscribe(HW_EVENT, HW_CONFIG_CHANGED, [&](const uint8_t* data, size_t size) {
+    if (size == 0 || data == nullptr) return;
     std::span<const uint8_t> payload(data, size);
     std::error_code ec;
     EventValueChanged s = alpaca::deserialize<EventValueChanged>(payload, ec);
-    if(!ec) {
-      ESP_LOGD(TAG, "Received hardware config event: %s -> %d (old=%d)", s.name.c_str(), s.newValue, s.oldValue);
-      uint8_t state = 0;
-      if(s.oldValue != 255 && GPIO_IS_VALID_OUTPUT_GPIO(s.oldValue)){
-        state = gpio_get_level(gpio_num_t(s.oldValue));
-        gpio_reset_pin(gpio_num_t(s.oldValue));
-        gpio_pullup_dis(gpio_num_t(s.oldValue));
-      } else ESP_LOGW(TAG, "Old GPIO %d is invalid", s.oldValue);
-      if(s.newValue != 255 && GPIO_IS_VALID_OUTPUT_GPIO(s.newValue)){
-        pinMode(s.newValue, OUTPUT);
-        if(s.name == "gpioActionPin")
-          digitalWrite(s.newValue, state);
-      } else ESP_LOGW(TAG, "New GPIO %d is invalid", s.newValue);
-    } else {
-      ESP_LOGE(TAG, "Failed to deserialize hardware config event: %s", ec.message().c_str());
+    if (ec) { 
+      ESP_LOGE(TAG, "Failed to deserialize hardware config event: %s", ec.message().c_str()); 
+      return; 
+    }
+
+    ESP_LOGD(TAG, "Received hardware config event: %s -> %d (old=%d)", s.name.c_str(), s.newValue, s.oldValue);
+
+    if (s.newValue == s.oldValue) return;
+
+    struct PinMeta {
+      PinFunctions func;
+      const char* config_name;
+      const char* tag;
+      gpio_mode_t default_mode;
+    };
+
+    static const PinMeta pin_meta_table[] = {
+      { ACTION,          "gpioActionPin",         "ACTION_PIN",      GPIO_MODE_OUTPUT },
+      { SUCCESS,         "nfcSuccessPin",         "SUCCESS_AUTH",    GPIO_MODE_OUTPUT },
+      { FAIL,            "nfcFailPin",            "FAIL_AUTH",       GPIO_MODE_OUTPUT },
+      { PIXEL,           "nfcNeopixelPin",        "NEOPIXEL_PIN",    GPIO_MODE_OUTPUT },
+      { ALT_ACTION,      "hkAltActionPin",        "ALT_ACTION",      GPIO_MODE_OUTPUT },
+      { ALT_ACTION_LED,  "hkAltActionInitLedPin", "ALT_ACTION_LED",  GPIO_MODE_OUTPUT },
+      { ALT_ACTION_INIT, "hkAltActionInitPin",    "INIT_ALT_ACTION", GPIO_MODE_INPUT  },
+      { TAG_EVENT,       "tagEventPin",           "TAG_EVENT_PIN",   GPIO_MODE_OUTPUT }
+    };
+
+    const PinMeta* meta = nullptr;
+    for (const auto& item : pin_meta_table) {
+      if (s.name == item.config_name) {
+        meta = &item;
+        break;
+      }
+    }
+
+    if (!meta) {
+      ESP_LOGW(TAG, "Unknown hardware config parameter: %s", s.name.c_str());
       return;
+    }
+
+    auto& alloc_entry = pinAllocations.at(meta->func);
+    gpio_mode_t mode = meta->default_mode;
+    bool level = false;
+
+    if (alloc_entry.has_value()) {
+      auto& lease = alloc_entry.value();
+      mode = lease.get_mode();
+      level = lease.get_level();
+
+      if (meta->func == PinFunctions::ALT_ACTION_INIT) {
+        gpio_isr_handler_remove(lease.get_pin());
+      }
+
+      alloc_entry = std::unexpected<GPIOAllocator::GPIOAllocatorError>(GPIOAllocator::INVALID_GPIO_NUM);
+      gpio_pulldown_en(gpio_num_t(s.oldValue));
+      ESP_LOGI(TAG, "Released pin for %s", meta->tag);
+    }
+
+    if (s.newValue == 255) {
+      ESP_LOGI(TAG, "%s set to undefined (255), stopping here.", meta->tag);
+      return;
+    }
+
+    if (GPIOAllocator::instance().owner_of(s.newValue).has_value()) {
+      ESP_LOGE(TAG, "Target pin %d already owned.", s.newValue);
+      return;
+    }
+
+    auto new_lease = GPIOAllocator::instance().acquire(gpio_num_t(s.newValue), mode, meta->tag);
+    if (new_lease.has_value()) {
+      if (mode != GPIO_MODE_INPUT) {
+        new_lease.value().set_level(level);
+      }
+
+      if (meta->func == PinFunctions::ALT_ACTION_INIT) {
+        new_lease.value().set_pullup(true);
+        gpio_set_intr_type(gpio_num_t(s.newValue), GPIO_INTR_NEGEDGE);
+        gpio_isr_handler_add(gpio_num_t(s.newValue), initiator_isr_handler, (void*)this);
+      }
+
+      alloc_entry = std::move(new_lease);
+      ESP_LOGI(TAG, "Acquired pin %d for %s", s.newValue, meta->tag);
+    } else {
+      ESP_LOGE(TAG, "Failed to acquire pin %d, error: %d", s.newValue, new_lease.error());
     }
   });
 }
@@ -113,29 +205,17 @@ void HardwareManager::begin() {
     ESP_LOGI(TAG, "Initializing hardware pins...");
 
     // --- Initialize GPIO Pins ---
-    if (m_miscConfig.nfcSuccessPin != 255) {
-        pinMode(m_miscConfig.nfcSuccessPin, OUTPUT);
-        digitalWrite(m_miscConfig.nfcSuccessPin, !m_miscConfig.nfcSuccessHL);
+    if(pinAllocations.at(SUCCESS).has_value()){
+      pinAllocations.at(SUCCESS).value().set_level(!m_miscConfig.nfcSuccessHL);
     }
-    if (m_miscConfig.nfcFailPin != 255) {
-        pinMode(m_miscConfig.nfcFailPin, OUTPUT);
-        digitalWrite(m_miscConfig.nfcFailPin, !m_miscConfig.nfcFailHL);
+    if(pinAllocations.at(FAIL).has_value()){
+      pinAllocations.at(FAIL).value().set_level(!m_miscConfig.nfcFailHL);
     }
-    if (m_miscConfig.tagEventPin != 255) {
-      pinMode(m_miscConfig.tagEventPin, OUTPUT);
-      digitalWrite(m_miscConfig.tagEventPin, !m_miscConfig.tagEventHL);
+    if(pinAllocations.at(TAG_EVENT).has_value()){
+      pinAllocations.at(TAG_EVENT).value().set_level(!m_miscConfig.tagEventHL);
     }
-    if (m_miscConfig.gpioActionPin != 255) {
-        pinMode(m_miscConfig.gpioActionPin, OUTPUT);
-    }
-    if (m_miscConfig.hkAltActionInitPin != 255) {
-      pinMode(m_miscConfig.hkAltActionInitPin, INPUT_PULLUP);
-      if (m_miscConfig.hkAltActionPin != 255) {
-        pinMode(m_miscConfig.hkAltActionPin, OUTPUT);
-      }
-      if (m_miscConfig.hkAltActionInitLedPin != 255) {
-        pinMode(m_miscConfig.hkAltActionInitLedPin, OUTPUT);
-      }
+    if(pinAllocations.at(ALT_ACTION_INIT).has_value()){
+      pinAllocations.at(ALT_ACTION_INIT).value().set_pullup(true);
       m_initiatorQueue = xQueueCreate(1, sizeof(uint8_t));
       xTaskCreateUniversal(initiator_task_entry, "initiator_task", 3580, this, 3, &m_initiatorTaskHandle, 1);
       gpio_install_isr_service(0);
@@ -144,7 +224,7 @@ void HardwareManager::begin() {
     }
 
     // --- Initialize NeoPixel ---
-    if (m_miscConfig.nfcNeopixelPin != 255) {
+    if (pinAllocations.at(PIXEL).has_value()) {
         size_t pixelTypeIndex = m_miscConfig.neoPixelType;
         if (pixelTypeIndex >= pixelTypeMap.size()) {
             ESP_LOGW(TAG, "Invalid NeoPixel type index (%d), defaulting to GRB.", pixelTypeIndex);
@@ -310,15 +390,15 @@ void HardwareManager::handleTimer(void* arg){
 
   switch (t) {
     case TimerSources::GPIO_S:
-      digitalWrite(i->m_miscConfig.nfcSuccessPin, !i->m_miscConfig.nfcSuccessHL);
+      if(i->pinAllocations.at(SUCCESS).has_value()) i->pinAllocations.at(SUCCESS).value().set_level(!i->m_miscConfig.nfcSuccessHL);
       ESP_LOGD(TAG, "GPIO_S");
       break;
     case TimerSources::GPIO_F:
-      digitalWrite(i->m_miscConfig.nfcFailPin, !i->m_miscConfig.nfcFailHL);
+      if(i->pinAllocations.at(FAIL).has_value()) i->pinAllocations.at(FAIL).value().set_level(!i->m_miscConfig.nfcFailHL);
       ESP_LOGD(TAG, "GPIO_F");
       break;
     case TimerSources::TAG_EVENT:
-      digitalWrite(i->m_miscConfig.tagEventPin, !i->m_miscConfig.tagEventHL);
+      if(i->pinAllocations.at(TAG_EVENT).has_value()) i->pinAllocations.at(TAG_EVENT).value().set_level(!i->m_miscConfig.tagEventHL);
       ESP_LOGD(TAG, "TAG_EVENT");
       break;
     case TimerSources::PIXEL_S:
@@ -328,14 +408,12 @@ void HardwareManager::handleTimer(void* arg){
       ESP_LOGD(TAG, "PIXEL");
       break;
     case TimerSources::ALT_GPIO:
-      digitalWrite(i->m_miscConfig.hkAltActionPin, !i->m_miscConfig.hkAltActionGpioState);
+      if(i->pinAllocations.at(ALT_ACTION).has_value()) i->pinAllocations.at(ALT_ACTION).value().set_level(!i->m_miscConfig.hkAltActionGpioState);
       ESP_LOGD(TAG, "ALT_GPIO");
       break;
     case TimerSources::ALT_GPIO_INIT:
       i->m_altActionArmed = false;
-      if (i->m_miscConfig.hkAltActionInitLedPin != 255) {
-        digitalWrite(i->m_miscConfig.hkAltActionInitLedPin, LOW);
-      }
+      if(i->pinAllocations.at(ALT_ACTION_LED).has_value()) i->pinAllocations.at(ALT_ACTION_LED).value().set_level(0);
       ESP_LOGD(TAG, "ALT_GPIO_INIT");
       break;
   }
@@ -385,9 +463,7 @@ void HardwareManager::initiator_task() {
             if (!m_altActionArmed) {
                 ESP_LOGI(TAG, "Alt action armed for %dms", m_miscConfig.hkAltActionInitTimeout);
                 m_altActionArmed = true;
-                if (m_miscConfig.hkAltActionInitLedPin != 255) {
-                    digitalWrite(m_miscConfig.hkAltActionInitLedPin, HIGH);
-                }
+                if(pinAllocations.at(ALT_ACTION_LED).has_value()) pinAllocations.at(ALT_ACTION_LED).value().set_level(1);
 
                 if (m_altActionInitTimer) esp_timer_start_once(m_altActionInitTimer, m_miscConfig.hkAltActionInitTimeout * 1000);
             }
@@ -419,13 +495,15 @@ void HardwareManager::lockControlTask() {
           }
           
           ESP_LOGI(TAG, "Setting lock output for state: %d", receivedState);
-          gpio_hold_dis((gpio_num_t)m_miscConfig.gpioActionPin);
+          gpio_hold_dis(pinAllocations.at(ACTION)->get_pin());
           if (receivedState == LockManager::LOCKED) {
-              digitalWrite(m_miscConfig.gpioActionPin, m_miscConfig.gpioActionLockState);
+            if(pinAllocations.at(ACTION).has_value())
+              pinAllocations.at(ACTION)->set_level(m_miscConfig.gpioActionLockState);
           } else if (receivedState == LockManager::UNLOCKED) {
-              digitalWrite(m_miscConfig.gpioActionPin, m_miscConfig.gpioActionUnlockState);
+            if(pinAllocations.at(ACTION).has_value())
+              pinAllocations.at(ACTION)->set_level(m_miscConfig.gpioActionUnlockState);
           }
-          gpio_hold_en((gpio_num_t)m_miscConfig.gpioActionPin);
+          gpio_hold_en(pinAllocations.at(ACTION)->get_pin());
           EventLockState s{
             .currentState = static_cast<uint8_t>(receivedState),
             .targetState = LockManager::UNKNOWN,
@@ -449,9 +527,9 @@ void HardwareManager::lockControlTask() {
 void HardwareManager::triggerAltAction() {
   if (m_altActionArmed) { 
       AppEventLoop::publish(HW_EVENT, HW_ALT_ACTION, nullptr, 0);
-      if (m_miscConfig.hkAltActionPin != 255) {
+      if (pinAllocations.at(ALT_ACTION).has_value()) {
           ESP_LOGI(TAG, "Triggering alt action on pin %d for %dms", m_miscConfig.hkAltActionPin, m_miscConfig.hkAltActionTimeout);
-          digitalWrite(m_miscConfig.hkAltActionPin, m_miscConfig.hkAltActionGpioState);
+          pinAllocations.at(ALT_ACTION)->set_level(m_miscConfig.hkAltActionGpioState);
           if (m_altActionTimer) esp_timer_start_once(m_altActionTimer, m_miscConfig.hkAltActionTimeout * 1000);
       }
   }
@@ -499,8 +577,8 @@ void HardwareManager::feedbackTask() {
 
                         if (m_pixelSuccessTimer) esp_timer_start_once(m_pixelSuccessTimer, m_miscConfig.neopixelSuccessTime * 1000);
                     }
-                    if (m_miscConfig.nfcSuccessPin != 255) {
-                        digitalWrite(m_miscConfig.nfcSuccessPin, m_miscConfig.nfcSuccessHL);
+                    if (pinAllocations.at(SUCCESS).has_value()) {
+                        pinAllocations.at(SUCCESS)->set_level(m_miscConfig.nfcSuccessHL);
 
                         if (m_gpioSuccessTimer) esp_timer_start_once(m_gpioSuccessTimer, m_miscConfig.nfcSuccessTime * 1000);
                     }
@@ -516,8 +594,8 @@ void HardwareManager::feedbackTask() {
 
                         if (m_pixelFailTimer) esp_timer_start_once(m_pixelFailTimer, m_miscConfig.neopixelFailTime * 1000);
                     }
-                    if (m_miscConfig.nfcFailPin != 255) {
-                        digitalWrite(m_miscConfig.nfcFailPin, m_miscConfig.nfcFailHL);
+                    if (pinAllocations.at(FAIL).has_value()) {
+                        pinAllocations.at(FAIL)->set_level(m_miscConfig.nfcFailHL);
 
                         if (m_gpioFailTimer) esp_timer_start_once(m_gpioFailTimer, m_miscConfig.nfcFailTime * 1000);
                     }
@@ -532,8 +610,8 @@ void HardwareManager::feedbackTask() {
 
                         if (m_pixelTagEventTimer) esp_timer_start_once(m_pixelTagEventTimer, m_miscConfig.neopixelTagEventTime * 1000);
                     }
-                    if (m_miscConfig.tagEventPin != 255) {
-                        digitalWrite(m_miscConfig.tagEventPin, m_miscConfig.tagEventHL);
+                    if (pinAllocations.at(TAG_EVENT).has_value()) {
+                        pinAllocations.at(TAG_EVENT)->set_level(m_miscConfig.tagEventHL);
 
                         if (m_tagEventTimer) esp_timer_start_once(m_tagEventTimer, m_miscConfig.tagEventTimeout * 1000);
                     }

--- a/main/HardwareManager.cpp
+++ b/main/HardwareManager.cpp
@@ -495,15 +495,19 @@ void HardwareManager::lockControlTask() {
           }
           
           ESP_LOGI(TAG, "Setting lock output for state: %d", receivedState);
-          gpio_hold_dis(pinAllocations.at(ACTION)->get_pin());
-          if (receivedState == LockManager::LOCKED) {
-            if(pinAllocations.at(ACTION).has_value())
-              pinAllocations.at(ACTION)->set_level(m_miscConfig.gpioActionLockState);
-          } else if (receivedState == LockManager::UNLOCKED) {
-            if(pinAllocations.at(ACTION).has_value())
-              pinAllocations.at(ACTION)->set_level(m_miscConfig.gpioActionUnlockState);
+          auto &action = pinAllocations.at(ACTION);
+          if(action.has_value()){
+            gpio_hold_dis(action->get_pin());
+          } else {
+            ESP_LOGW(TAG, "GPIOLease not held for action pin; skipping lock output");
+            continue;
           }
-          gpio_hold_en(pinAllocations.at(ACTION)->get_pin());
+          if (receivedState == LockManager::LOCKED) {
+              action->set_level(m_miscConfig.gpioActionLockState);
+          } else if (receivedState == LockManager::UNLOCKED) {
+              action->set_level(m_miscConfig.gpioActionUnlockState);
+          }
+          gpio_hold_en(action->get_pin());
           EventLockState s{
             .currentState = static_cast<uint8_t>(receivedState),
             .targetState = LockManager::UNKNOWN,

--- a/main/HardwareManager.cpp
+++ b/main/HardwareManager.cpp
@@ -118,6 +118,8 @@ HardwareManager::HardwareManager(const espConfig::actions_config_t& miscConfig)
       level = lease.get_level();
 
       if (meta->func == PinFunctions::ALT_ACTION_INIT) {
+        // We don't uninstall the ISR as it might be used by the Ethernet driver
+        // and HardwareManager doesn't have access to misc_config_t to check
         gpio_isr_handler_remove(lease.get_pin());
       }
 
@@ -144,6 +146,10 @@ HardwareManager::HardwareManager(const espConfig::actions_config_t& miscConfig)
 
       if (meta->func == PinFunctions::ALT_ACTION_INIT) {
         new_lease.value().set_pullup(true);
+        if(!isr_service_installed){
+          esp_err_t err = gpio_install_isr_service(0);
+          if(err == ESP_OK || err == ESP_ERR_INVALID_STATE) isr_service_installed = true;
+        }
         gpio_set_intr_type(gpio_num_t(s.newValue), GPIO_INTR_NEGEDGE);
         gpio_isr_handler_add(gpio_num_t(s.newValue), initiator_isr_handler, (void*)this);
       }
@@ -218,7 +224,9 @@ void HardwareManager::begin() {
       pinAllocations.at(ALT_ACTION_INIT).value().set_pullup(true);
       m_initiatorQueue = xQueueCreate(1, sizeof(uint8_t));
       xTaskCreateUniversal(initiator_task_entry, "initiator_task", 3580, this, 3, &m_initiatorTaskHandle, 1);
-      gpio_install_isr_service(0);
+      if(esp_err_t err = gpio_install_isr_service(0); err == ESP_OK || err == ESP_ERR_INVALID_STATE){
+        isr_service_installed = true;
+      }
       gpio_set_intr_type((gpio_num_t)m_miscConfig.hkAltActionInitPin, GPIO_INTR_NEGEDGE);
       gpio_isr_handler_add((gpio_num_t)m_miscConfig.hkAltActionInitPin, initiator_isr_handler, (void*) this);
     }

--- a/main/HomeKitLock.cpp
+++ b/main/HomeKitLock.cpp
@@ -497,9 +497,7 @@ void HomeKitLock::setupDebugCommands() {
     new SpanUserCommand('G', "Who owns this GPIO Pin?", [](const char* c) {
       uint8_t i = atoi(c+1);
       auto s = GPIOAllocator::instance().owner_of(i);
-      if(s.has_value()){
-          ESP_LOGI(TAG, "Owner: %s", s.value_or("Not allocated").c_str());
-      }
+      ESP_LOGI(TAG, "Owner: %s", s.has_value() ? s->c_str() : "Not allocated");
     });
 }
 

--- a/main/HomeKitLock.cpp
+++ b/main/HomeKitLock.cpp
@@ -1,9 +1,11 @@
+#include "HardwareManager.hpp"
 #include "fmt/ranges.h"
 #include "config.hpp"
 #include "esp_log.h"
 #include "eth_structs.hpp"
 #include "eventStructs.hpp"
 #include "HomeKitLock.hpp"
+#include <cstdint>
 #include <functional>
 #include <sodium/crypto_sign.h>
 #include <sodium/crypto_box.h>
@@ -125,81 +127,179 @@ void HomeKitLock::ethEventHandler(arduino_event_id_t event, arduino_event_info_t
  * - If a configuration requires a built-in EMAC but the build does not include
  *   CONFIG_ETH_USE_ESP32_EMAC, logs an error and does not initialize Ethernet.
  */
-void HomeKitLock::initializeETH(){
+void HomeKitLock::initializeETH() {
   const auto& miscConfig = m_configManager.getConfig<espConfig::misc_config_t>();
 
-    if (!miscConfig.ethernetEnabled) {
-        ESP_LOGI(TAG, "Ethernet is disabled. HomeSpan will manage Wi-Fi.");
-        return; // Do nothing and let HomeSpan handle Wi-Fi
+  if (!miscConfig.ethernetEnabled) {
+    ESP_LOGI(TAG, "Ethernet is disabled. HomeSpan will manage Wi-Fi.");
+    return;
+  }
+
+  ESP_LOGI(TAG, "Ethernet is enabled. Initializing...");
+
+  spi_host_device_t spiHost = SPI2_HOST;
+  if (miscConfig.ethSpiBus < static_cast<unsigned char>(SPI_HOST_MAX)) {
+    spiHost = static_cast<spi_host_device_t>(miscConfig.ethSpiBus);
+  } else {
+    ESP_LOGW(TAG, "ethSpiBus out of range (%u). Defaulting to SPI2_HOST.", static_cast<unsigned>(miscConfig.ethSpiBus));
+  }
+
+  uint8_t eth_sck = 255;
+  uint8_t eth_miso = 255;
+  uint8_t eth_mosi = 255;
+  uint8_t eth_cs = 255;
+  uint8_t eth_irq = 255;
+  uint8_t eth_rst = 255;
+  bool is_spi_ethernet = false;
+  eth_phy_type_t phy_type;
+
+  if (miscConfig.ethActivePreset != 255) {
+    if (miscConfig.ethActivePreset >= eth_config_ns::boardPresets.size()) {
+      ESP_LOGE(TAG, "Invalid ethActivePreset index (%d). Not initializing Ethernet.", miscConfig.ethActivePreset);
+      return;
     }
+    const eth_board_presets_t& ethPreset = eth_config_ns::boardPresets[miscConfig.ethActivePreset];
+    is_spi_ethernet = !ethPreset.ethChip.emac;
+    phy_type = ethPreset.ethChip.phy_type;
+    if (is_spi_ethernet) {
+      eth_sck = ethPreset.spi_conf.pin_sck;
+      eth_miso = ethPreset.spi_conf.pin_miso;
+      eth_mosi = ethPreset.spi_conf.pin_mosi;
+      eth_cs = ethPreset.spi_conf.pin_cs;
+      eth_irq = ethPreset.spi_conf.pin_irq;
+      eth_rst = ethPreset.spi_conf.pin_rst;
+    }
+  } else {
+    phy_type = static_cast<eth_phy_type_t>(miscConfig.ethPhyType);
+    if (eth_config_ns::supportedChips.count(phy_type) == 0) {
+      ESP_LOGE(TAG, "Custom phy_type (%d) is not supported.", miscConfig.ethPhyType);
+      return;
+    }
+    const eth_chip_desc_t& chipType = eth_config_ns::supportedChips.at(phy_type);
+    is_spi_ethernet = !chipType.emac;
+    if (is_spi_ethernet) {
+      eth_sck = miscConfig.ethSpiConfig[4];
+      eth_miso = miscConfig.ethSpiConfig[5];
+      eth_mosi = miscConfig.ethSpiConfig[6];
+      eth_cs = miscConfig.ethSpiConfig[1];
+      eth_irq = miscConfig.ethSpiConfig[2];
+      eth_rst = miscConfig.ethSpiConfig[3];
+    }
+  }
 
-    ESP_LOGI(TAG,"Ethernet is enabled. Initializing...");
-    Network.onEvent(ethEventHandler);
+  if (is_spi_ethernet) {
+    static std::vector<GPIOAllocator::GPIOLease> eth_leases;
+    eth_leases.clear();
 
-    const auto& spiBus = miscConfig.ethSpiBus;
-        // Convert and validate config uint8_t -> spi_host_device_t
-    spi_host_device_t spiHost = SPI2_HOST; // safe default
-    if (spiBus < static_cast<unsigned char>(SPI_HOST_MAX)) {
-        spiHost = static_cast<spi_host_device_t>(spiBus);
+    auto owner_sck = GPIOAllocator::instance().owner_of(eth_sck);
+    auto owner_miso = GPIOAllocator::instance().owner_of(eth_miso);
+    auto owner_mosi = GPIOAllocator::instance().owner_of(eth_mosi);
+
+    bool sck_shared_with_nfc = (owner_sck == "SPI2_SCK");
+    bool miso_shared_with_nfc = (owner_miso == "SPI2_MISO");
+    bool mosi_shared_with_nfc = (owner_mosi == "SPI2_MOSI");
+
+    if (spiHost == SPI2_HOST) {
+      if (!sck_shared_with_nfc || !miso_shared_with_nfc || !mosi_shared_with_nfc) {
+        ESP_LOGE(TAG, "Ethernet conflict: When using SPI2, Ethernet must share the exact same SCK/MISO/MOSI pins as NFC.");
+        ESP_LOGE(TAG, "Current owners - SCK (%d): %s, MISO (%d): %s, MOSI (%d): %s",
+                 eth_sck, owner_sck.value_or("free").data(),
+                 eth_miso, owner_miso.value_or("free").data(),
+                 eth_mosi, owner_mosi.value_or("free").data());
+        return; 
+      }
+      ESP_LOGI(TAG, "Ethernet is verified to share the SPI2 bus pins with the NFC module.");
     } else {
-        ESP_LOGW(TAG, "ethSpiBus out of range (%u). Defaulting to SPI2_HOST.", static_cast<unsigned>(spiBus));
+      if (owner_sck.has_value() || owner_miso.has_value() || owner_mosi.has_value()) {
+        ESP_LOGE(TAG, "Ethernet conflict: One or more SPI pins for Ethernet are already allocated.");
+        ESP_LOGE(TAG, "Current owners - SCK (%d): %s, MISO (%d): %s, MOSI (%d): %s",
+                 eth_sck, owner_sck.value_or("free").data(),
+                 eth_miso, owner_miso.value_or("free").data(),
+                 eth_mosi, owner_mosi.value_or("free").data());
+        return; 
+      }
+
+      auto lease_sck = GPIOAllocator::instance().acquire(gpio_num_t(eth_sck), GPIO_MODE_DISABLE, "ETH_SPI_SCK");
+      auto lease_miso = GPIOAllocator::instance().acquire(gpio_num_t(eth_miso), GPIO_MODE_DISABLE, "ETH_SPI_MISO");
+      auto lease_mosi = GPIOAllocator::instance().acquire(gpio_num_t(eth_mosi), GPIO_MODE_DISABLE, "ETH_SPI_MOSI");
+
+      if (lease_sck.has_value() && lease_miso.has_value() && lease_mosi.has_value()) {
+        eth_leases.push_back(std::move(lease_sck.value()));
+        eth_leases.push_back(std::move(lease_miso.value()));
+        eth_leases.push_back(std::move(lease_mosi.value()));
+        ESP_LOGI(TAG, "Allocated Ethernet SPI Host pins (SCK: %d, MISO: %d, MOSI: %d)", eth_sck, eth_miso, eth_mosi);
+      } else {
+        ESP_LOGE(TAG, "Failed to allocate Ethernet SPI Host pins.");
+        eth_leases.clear();
+        return;
+      }
     }
 
-    // --- Preset-based Configuration ---
-    if (miscConfig.ethActivePreset != 255) {
-        if (miscConfig.ethActivePreset >= eth_config_ns::boardPresets.size()) {
-            ESP_LOGE(TAG,"Invalid ethActivePreset index (%d). Not initializing Ethernet.", miscConfig.ethActivePreset);
-            return;
-        }
+    auto check_and_allocate = [&](uint8_t pin, const std::string& tag_name, gpio_mode_t mode) -> bool {
+      if (pin == 255) return true;
+      auto owner = GPIOAllocator::instance().owner_of(pin);
+      if (owner.has_value()) {
+        ESP_LOGE(TAG, "Pin %d for %s is already allocated to '%s'.", pin, tag_name.c_str(), owner.value().data());
+        return false;
+      }
+      auto lease = GPIOAllocator::instance().acquire(gpio_num_t(pin), mode, tag_name);
+      if (lease.has_value()) {
+        eth_leases.push_back(std::move(lease.value()));
+        return true;
+      } else {
+        ESP_LOGE(TAG, "Failed to allocate Pin %d for %s.", pin, tag_name.c_str());
+        return false;
+      }
+    };
 
-        const eth_board_presets_t& ethPreset = eth_config_ns::boardPresets[miscConfig.ethActivePreset];
-        ESP_LOGI(TAG,"Initializing with preset: %s", ethPreset.name.c_str());
-
-        if (!ethPreset.ethChip.emac) {
-            // SPI-based Ethernet Module
-            const auto& spiConf = ethPreset.spi_conf;
-            ETH.begin(ethPreset.ethChip.phy_type, 1, spiConf.pin_cs, spiConf.pin_irq, spiConf.pin_rst,
-                      spiHost, spiConf.pin_sck, spiConf.pin_miso, spiConf.pin_mosi, spiConf.spi_freq_mhz);
-        } else {
-            // Internal MAC (RMII) Ethernet Module
-            #if CONFIG_ETH_USE_ESP32_EMAC
-            const auto& rmiiConf = ethPreset.rmii_conf;
-            ETH.begin(ethPreset.ethChip.phy_type, rmiiConf.phy_addr, rmiiConf.pin_mcd, rmiiConf.pin_mdio,
-                      rmiiConf.pin_power, rmiiConf.pin_rmii_clock);
-            #else
-            ESP_LOGE(TAG,"Preset requires EMAC, but this board does not have a built-in Ethernet MAC.");
-            #endif
-        }
+    if (!check_and_allocate(eth_cs, "ETH_SPI_CS", GPIO_MODE_DISABLE) ||
+        !check_and_allocate(eth_irq, "ETH_SPI_IRQ", GPIO_MODE_INPUT) ||
+        !check_and_allocate(eth_rst, "ETH_SPI_RST", GPIO_MODE_OUTPUT)) {
+      eth_leases.clear();
+      return;
     }
-    // --- Custom Configuration ---
-    else {
-        ESP_LOGI(TAG,"Initializing with custom pin configuration.");
-        auto phy_type = static_cast<eth_phy_type_t>(miscConfig.ethPhyType);
-        
-        if (eth_config_ns::supportedChips.count(phy_type) == 0) {
-            ESP_LOGE(TAG,"Custom phy_type (%d) is not supported.", miscConfig.ethPhyType);
-            return;
-        }
+  }
 
-        const eth_chip_desc_t& chipType = eth_config_ns::supportedChips.at(phy_type);
-        
-        if (!chipType.emac) {
-            // Custom SPI pins
-            const auto& spiConf = miscConfig.ethSpiConfig;
+  Network.onEvent(ethEventHandler);
 
-            ETH.begin(chipType.phy_type, 1, spiConf[1], spiConf[2], spiConf[3],
-                      spiHost, spiConf[4], spiConf[5], spiConf[6], spiConf[0]);
-        } else {
-            // Custom RMII pins
-            #if CONFIG_ETH_USE_ESP32_EMAC
-            const auto& rmiiConf = miscConfig.ethRmiiConfig;
-            ETH.begin(chipType.phy_type, rmiiConf[0], rmiiConf[1], rmiiConf[2], rmiiConf[3],
-                      static_cast<eth_clock_mode_t>(rmiiConf[4]));
-            #else
-            ESP_LOGE(TAG,"Custom config requires EMAC, but this board does not have a built-in Ethernet MAC.");
-            #endif
-        }
+  // --- Preset-based Configuration ---
+  if (miscConfig.ethActivePreset != 255) {
+    const eth_board_presets_t& ethPreset = eth_config_ns::boardPresets[miscConfig.ethActivePreset];
+    ESP_LOGI(TAG, "Initializing with preset: %s", ethPreset.name.c_str());
+
+    if (!ethPreset.ethChip.emac) {
+      const auto& spiConf = ethPreset.spi_conf;
+      ETH.begin(ethPreset.ethChip.phy_type, 1, spiConf.pin_cs, spiConf.pin_irq, spiConf.pin_rst,
+                spiHost, spiConf.pin_sck, spiConf.pin_miso, spiConf.pin_mosi, spiConf.spi_freq_mhz);
+    } else {
+#if CONFIG_ETH_USE_ESP32_EMAC
+      const auto& rmiiConf = ethPreset.rmii_conf;
+      ETH.begin(ethPreset.ethChip.phy_type, rmiiConf.phy_addr, rmiiConf.pin_mcd, rmiiConf.pin_mdio,
+                rmiiConf.pin_power, rmiiConf.pin_rmii_clock);
+#else
+      ESP_LOGE(TAG, "Preset requires EMAC, but this board does not have a built-in Ethernet MAC.");
+#endif
     }
+  }
+  // --- Custom Configuration ---
+  else {
+    ESP_LOGI(TAG, "Initializing with custom pin configuration.");
+    const eth_chip_desc_t& chipType = eth_config_ns::supportedChips.at(phy_type);
+
+    if (!chipType.emac) {
+      const auto& spiConf = miscConfig.ethSpiConfig;
+      ETH.begin(chipType.phy_type, 1, spiConf[1], spiConf[2], spiConf[3],
+                spiHost, spiConf[4], spiConf[5], spiConf[6], spiConf[0]);
+    } else {
+#if CONFIG_ETH_USE_ESP32_EMAC
+      const auto& rmiiConf = miscConfig.ethRmiiConfig;
+      ETH.begin(chipType.phy_type, rmiiConf[0], rmiiConf[1], rmiiConf[2], rmiiConf[3],
+                static_cast<eth_clock_mode_t>(rmiiConf[4]));
+#else
+      ESP_LOGE(TAG, "Custom config requires EMAC, but this board does not have a built-in Ethernet MAC.");
+#endif
+    }
+  }
 }
 /**
  * @brief Initialize HomeSpan, expose lock-related accessories/services, and register runtime callbacks.
@@ -389,6 +489,13 @@ void HomeKitLock::setupDebugCommands() {
                  fmt::format("{:02X}", fmt::join(issuer.issuer_pk, "")).c_str());
         }
         ESP_LOGI(TAG, "------------------------------------");
+    });
+    new SpanUserCommand('G', "Who owns this GPIO Pin?", [](const char* c) {
+      uint8_t i = atoi(c+1);
+      auto s = GPIOAllocator::instance().owner_of(i);
+      if(s.has_value()){
+          ESP_LOGI(TAG, "Owner: %s", s.value_or("Not allocated").c_str());
+      }
     });
 }
 

--- a/main/HomeKitLock.cpp
+++ b/main/HomeKitLock.cpp
@@ -190,7 +190,11 @@ void HomeKitLock::initializeETH() {
   if (is_spi_ethernet) {
     static std::vector<GPIOAllocator::GPIOLease> eth_leases;
     eth_leases.clear();
-
+    if (eth_sck == 255 || eth_miso == 255 || eth_mosi == 255 || eth_cs == 255) {
+      ESP_LOGE(TAG, "One or more required GPIO Pins for SPI Ethernet are not "
+                    "defined, cannot setup Ethernet.");
+      return;
+    }
     auto owner_sck = GPIOAllocator::instance().owner_of(eth_sck);
     auto owner_miso = GPIOAllocator::instance().owner_of(eth_miso);
     auto owner_mosi = GPIOAllocator::instance().owner_of(eth_mosi);

--- a/main/NfcManager.cpp
+++ b/main/NfcManager.cpp
@@ -8,6 +8,7 @@
 #include "DDKAuthContext.h"
 #include "Pn532Reader.hpp"
 #include "Pn7160Reader.hpp"
+#include "hal/gpio_types.h"
 #include "utils.hpp"
 
 #include <array>
@@ -226,6 +227,14 @@ NfcManager::NfcManager(ReaderDataManager& readerDataManager,
       m_retryTaskHandle(nullptr),
       m_ecpData({ 0x6A, 0x2, 0xCB, 0x2, 0x6, 0x2, 0x11, 0x0 })
 {
+  pinAllocations.emplace(PinFunctions::SS, GPIOAllocator::instance().acquire(gpio_num_t(nfcGpioPins[0]), GPIO_MODE_DISABLE, "SPI2_SS"));
+  pinAllocations.emplace(PinFunctions::SCK, GPIOAllocator::instance().acquire(gpio_num_t(nfcGpioPins[1]), GPIO_MODE_DISABLE, "SPI2_SCK"));
+  pinAllocations.emplace(PinFunctions::MISO, GPIOAllocator::instance().acquire(gpio_num_t(nfcGpioPins[2]), GPIO_MODE_DISABLE, "SPI2_MISO"));
+  pinAllocations.emplace(PinFunctions::MOSI, GPIOAllocator::instance().acquire(gpio_num_t(nfcGpioPins[3]), GPIO_MODE_DISABLE, "SPI2_MOSI"));
+  if(nfcIrqPin != 255)
+    pinAllocations.emplace(PinFunctions::IRQ, GPIOAllocator::instance().acquire(gpio_num_t(nfcIrqPin), GPIO_MODE_DISABLE, "NFC_IRQ"));
+  if(nfcVenPin != 255)
+    pinAllocations.emplace(PinFunctions::VEN, GPIOAllocator::instance().acquire(gpio_num_t(nfcVenPin), GPIO_MODE_DISABLE, "NFC_VEN"));
   m_hk_event = AppEventLoop::subscribe(HK_EVENT, HK_INTERNAL_EVENT, [&](const uint8_t* data, size_t size){
     if(size == 0 || data == nullptr) return;
     std::span<const uint8_t> payload(data, size);

--- a/main/WebServerManager.cpp
+++ b/main/WebServerManager.cpp
@@ -1118,6 +1118,24 @@ bool WebServerManager::validateRequest(httpd_req_t *req, cJSON *currentData,
         std::string response = cjson_to_string_and_free(res);
         httpd_resp_send(req, response.c_str(), HTTPD_RESP_USE_STRLEN);
         return false;
+    } else if ((str_ends_with(keyStr.c_str(), "Pins") || str_ends_with(keyStr.c_str(), "SpiConfig")) && cJSON_IsArray(incomingValue)){
+      cJSON *el = NULL;
+      cJSON_ArrayForEach(el, incomingValue) {
+        if(cJSON_IsNumber(el)){
+          if(auto owner = GPIOAllocator::instance().owner_of(el->valueint); owner.has_value() && !owner->contains("SPI")) {
+            std::string msg = std::to_string(el->valueint) +
+                              " for \"" + keyStr + "\" already owned by \"" + owner.value() + "\".";
+            httpd_resp_set_type(req, "application/json");
+            httpd_resp_set_status(req, "400 Bad Request");
+            cJSON *res = cJSON_CreateObject();
+            cJSON_AddItemToObject(res, "success", cJSON_CreateBool(false));
+            cJSON_AddItemToObject(res, "error", cJSON_CreateString(msg.c_str()));
+            std::string response = cjson_to_string_and_free(res);
+            httpd_resp_send(req, response.c_str(), HTTPD_RESP_USE_STRLEN);
+            return false;
+          }
+        }
+      };
     }
 
     // Boolean coercion

--- a/main/WebServerManager.cpp
+++ b/main/WebServerManager.cpp
@@ -2,6 +2,7 @@
 // WebServerManager.cpp - ESP32 Web Server Implementation
 // ============================================================================
 
+#include "GPIOAllocator.hpp"
 #include "esp_https_server.h"
 #include "esp_ota_ops.h"
 #include "esp_system.h"
@@ -881,8 +882,7 @@ esp_err_t WebServerManager::handleSaveConfig(httpd_req_t *req) {
     } else if (keyStr == "nfcNeopixelPin") {
       rebootNeeded = true;
       rebootMsg = "Pixel GPIO pin changed, reboot needed! Rebooting...";
-    } else if (keyStr == "nfcSuccessPin" || keyStr == "nfcFailPin" ||
-               keyStr == "gpioActionPin") {
+    } else if (str_ends_with(keyStr.c_str(), "Pin")) {
       EventValueChanged s{.name = keyStr,
                           .oldValue = (uint8_t)configSchemaItem->valueint,
                           .newValue = (uint8_t)it->valueint};
@@ -1086,6 +1086,18 @@ bool WebServerManager::validateRequest(httpd_req_t *req, cJSON *currentData,
                                                  !GPIO_IS_VALID_OUTPUT_GPIO(pin)) {
         std::string msg = std::to_string(pin) +
                           " is not a valid GPIO Pin for \"" + keyStr + "\".";
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_set_status(req, "400 Bad Request");
+        cJSON *res = cJSON_CreateObject();
+        cJSON_AddItemToObject(res, "success", cJSON_CreateBool(false));
+        cJSON_AddItemToObject(res, "error", cJSON_CreateString(msg.c_str()));
+        std::string response = cjson_to_string_and_free(res);
+        httpd_resp_send(req, response.c_str(), HTTPD_RESP_USE_STRLEN);
+        return false;
+      }
+      if(auto owner = GPIOAllocator::instance().owner_of(incomingValue->valueint); owner.has_value()){
+        std::string msg = std::to_string(incomingValue->valueint) +
+                          " for \"" + keyStr + "\" already owned by \"" + owner.value() + "\".";
         httpd_resp_set_type(req, "application/json");
         httpd_resp_set_status(req, "400 Bad Request");
         cJSON *res = cJSON_CreateObject();

--- a/main/include/GPIOAllocator.hpp
+++ b/main/include/GPIOAllocator.hpp
@@ -1,0 +1,108 @@
+#pragma once
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "hal/gpio_types.h"
+#include "soc/gpio_num.h"
+#include <array>
+#include <cstdint>
+#include <expected>
+#include <mutex>
+#include <optional>
+#include <string>
+
+class GPIOAllocator {
+public:
+  static GPIOAllocator& instance() {
+    static GPIOAllocator instance;
+    return instance;
+  }
+  enum GPIOAllocatorError {
+    INVALID_GPIO_NUM = 0,
+    INVALID_GPIO_DIRECTION = 1,
+    ALREADY_OWNED = 2,
+  };
+
+  class GPIOLease {
+  public:
+    GPIOLease() = delete;
+    GPIOLease(const GPIOLease&) = delete;
+    GPIOLease& operator=(const GPIOLease&) = delete;
+    GPIOLease(GPIOLease&& other) noexcept : pin_(other.pin_), mode_(other.mode_) {
+      other.pin_ = GPIO_NUM_NC;
+    }
+
+    GPIOLease& operator=(GPIOLease&& other) noexcept {
+      if (this != &other) {
+        reset();
+        pin_ = other.pin_;
+        mode_ = other.mode_;
+        other.pin_ = GPIO_NUM_NC;
+      }
+      return *this;
+    }
+    ~GPIOLease() { if(pin_ != GPIO_NUM_NC) { reset(); } };
+    void set_level(bool level) { gpio_set_level(pin_, level); };
+    bool get_level() const { return gpio_get_level(pin_); };
+    gpio_mode_t get_mode() const { return mode_; };
+    void set_direction(gpio_mode_t mode) { gpio_set_direction(pin_, mode); };
+    void set_pullup(bool val) { val ? gpio_pullup_en(pin_) : gpio_pullup_dis(pin_); };
+    void set_pulldown(bool val) { val ? gpio_pulldown_en(pin_) : gpio_pulldown_dis(pin_); };
+    gpio_num_t get_pin() const { return pin_; };
+
+  private:
+    friend class GPIOAllocator;
+    GPIOLease(gpio_num_t pin, gpio_mode_t mode) : pin_(pin), mode_(mode) {gpio_set_direction(pin, mode);};
+    void reset() {
+      if (pin_ != GPIO_NUM_NC && pin_ >= 0 && pin_ < GPIO_NUM_MAX) {
+        gpio_reset_pin(pin_);
+        std::lock_guard lock(GPIOAllocator::mutex_);
+        GPIOAllocator::owners_[pin_].clear();
+      }
+      pin_ = GPIO_NUM_NC;
+    }
+    gpio_num_t pin_ = GPIO_NUM_NC;
+    gpio_mode_t mode_ = GPIO_MODE_INPUT_OUTPUT_OD;
+  };
+
+  std::expected<GPIOLease, GPIOAllocatorError> acquire(gpio_num_t pin, gpio_mode_t mode, const std::string &tag) {
+    std::lock_guard lock(mutex_);
+    ESP_LOGI("GPIOAllocator", "Allocating GPIO Pin for '%s'", tag.c_str());
+    if(pin > GPIO_NUM_MAX || pin == GPIO_NUM_NC){
+      ESP_LOGE("GPIOAllocator", "'%d' Outside gpio number range or undefined pin", pin);
+      return std::unexpected<GPIOAllocatorError>(INVALID_GPIO_NUM);
+    }
+    if(!GPIO_IS_VALID_GPIO(pin)){
+      ESP_LOGE("GPIOAllocator", "INVALID GPIO NUMBER!");
+      return std::unexpected<GPIOAllocatorError>(INVALID_GPIO_NUM);
+    }
+    if((mode == GPIO_MODE_OUTPUT || mode == GPIO_MODE_INPUT_OUTPUT || mode == GPIO_MODE_OUTPUT_OD || mode == GPIO_MODE_INPUT_OUTPUT_OD) && !GPIO_IS_VALID_OUTPUT_GPIO(pin)) {
+      ESP_LOGE("GPIOAllocator", "Invalid GPIO Direction!");
+      return std::unexpected<GPIOAllocatorError>(INVALID_GPIO_DIRECTION);
+    }
+    if(!owners_[pin].empty()){
+      ESP_LOGE("GPIOAllocator", "GPIO already owned!");
+      return std::unexpected<GPIOAllocatorError>(ALREADY_OWNED);
+    }
+    owners_[pin] = tag;
+    return GPIOLease(pin, mode);
+  }
+
+  [[nodiscard]] std::optional<std::string> owner_of(uint8_t pin) const {
+    std::lock_guard lock(mutex_);
+    ESP_LOGD("GPIOAllocator", "Owners Size: %d Pin: %d Owner: %s", owners_.size(), pin, owners_[pin].c_str());
+    if (pin >= owners_.size() || owners_[pin].empty()) {
+        return std::nullopt;
+    }
+    return owners_[pin];
+  }
+private:
+  GPIOAllocator() = default;
+  ~GPIOAllocator() = default;
+  GPIOAllocator(const GPIOAllocator&) = delete;
+  GPIOAllocator& operator=(const GPIOAllocator&) = delete;
+  GPIOAllocator(GPIOAllocator&&) = delete;
+  GPIOAllocator& operator=(GPIOAllocator&&) = delete;
+  friend class GPIOLease;
+  static std::mutex mutex_;
+  static std::array<std::string, GPIO_NUM_MAX> owners_;
+};

--- a/main/include/GPIOAllocator.hpp
+++ b/main/include/GPIOAllocator.hpp
@@ -67,7 +67,7 @@ public:
   std::expected<GPIOLease, GPIOAllocatorError> acquire(gpio_num_t pin, gpio_mode_t mode, const std::string &tag) {
     std::lock_guard lock(mutex_);
     ESP_LOGI("GPIOAllocator", "Allocating GPIO Pin for '%s'", tag.c_str());
-    if(pin > GPIO_NUM_MAX || pin == GPIO_NUM_NC){
+    if(pin >= GPIO_NUM_MAX || pin == GPIO_NUM_NC){
       ESP_LOGE("GPIOAllocator", "'%d' Outside gpio number range or undefined pin", pin);
       return std::unexpected<GPIOAllocatorError>(INVALID_GPIO_NUM);
     }
@@ -89,10 +89,10 @@ public:
 
   [[nodiscard]] std::optional<std::string> owner_of(uint8_t pin) const {
     std::lock_guard lock(mutex_);
-    ESP_LOGD("GPIOAllocator", "Owners Size: %d Pin: %d Owner: %s", owners_.size(), pin, owners_[pin].c_str());
     if (pin >= owners_.size() || owners_[pin].empty()) {
         return std::nullopt;
     }
+    ESP_LOGD("GPIOAllocator", "Owners Size: %d Pin: %d Owner: %s", owners_.size(), pin, owners_[pin].c_str());
     return owners_[pin];
   }
 private:

--- a/main/include/HardwareManager.hpp
+++ b/main/include/HardwareManager.hpp
@@ -5,6 +5,9 @@
 #include "freertos/task.h"
 #include "freertos/queue.h"
 #include <cstdint>
+#include <expected>
+#include <map>
+#include "GPIOAllocator.hpp"
 
 class ConfigManager;
 class Pixel;
@@ -139,4 +142,17 @@ private:
     AppEventLoop::SubscriptionHandle m_hardware_action_event;
     AppEventLoop::SubscriptionHandle m_nfc_event;
     AppEventLoop::SubscriptionHandle m_gpio_pin_event;
+
+    enum PinFunctions {
+      ACTION,
+      SUCCESS,
+      FAIL,
+      PIXEL,
+      ALT_ACTION,
+      ALT_ACTION_INIT,
+      ALT_ACTION_LED,
+      TAG_EVENT
+    };
+
+    std::map<PinFunctions, std::expected<GPIOAllocator::GPIOLease, GPIOAllocator::GPIOAllocatorError>> pinAllocations;
 };

--- a/main/include/HardwareManager.hpp
+++ b/main/include/HardwareManager.hpp
@@ -155,4 +155,5 @@ private:
     };
 
     std::map<PinFunctions, std::expected<GPIOAllocator::GPIOLease, GPIOAllocator::GPIOAllocatorError>> pinAllocations;
+    bool isr_service_installed;
 };

--- a/main/include/NfcManager.hpp
+++ b/main/include/NfcManager.hpp
@@ -5,10 +5,13 @@
 #include "freertos/task.h"
 #include <array>
 #include <atomic>
+#include <expected>
 #include <functional>
+#include <map>
 #include <memory>
 #include "app_event_loop.hpp"
 #include "NfcReader.hpp"
+#include "GPIOAllocator.hpp"
 
 class LockManager;
 class HardwareManager;
@@ -92,6 +95,16 @@ private:
 
     static const char* TAG;
     AppEventLoop::SubscriptionHandle m_hk_event;
+    enum PinFunctions {
+      SCK,
+      MISO,
+      MOSI,
+      SS,
+      IRQ,
+      VEN
+    };
+
+    std::map<PinFunctions, std::expected<GPIOAllocator::GPIOLease, GPIOAllocator::GPIOAllocatorError>> pinAllocations;
 
 public:
     /**

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -130,49 +130,16 @@ void setup() {
     ESP_LOGI(TAG, "NFC IRQ pin: %d, VEN pin: %d", miscConfig.nfcIrqPin, miscConfig.nfcVenPin);
   }
   readerDataManager->begin();
-  if(miscConfig.ethernetEnabled){
-    std::vector<uint8_t> ethPins;
-    if(miscConfig.ethActivePreset == PIN_UNSET){
-      ethPins = {miscConfig.ethSpiConfig[4], miscConfig.ethSpiConfig[5], miscConfig.ethSpiConfig[6]};
-    } else { 
-        const eth_board_presets_t& ethPreset = eth_config_ns::boardPresets[miscConfig.ethActivePreset];
-        ethPins = {ethPreset.spi_conf.pin_sck, ethPreset.spi_conf.pin_miso, ethPreset.spi_conf.pin_mosi};
-    }
-    std::vector<uint8_t> nfcPins;
-    if(miscConfig.nfcPinsPreset == PIN_UNSET){
-      nfcPins = {miscConfig.nfcGpioPins[1], miscConfig.nfcGpioPins[2], miscConfig.nfcGpioPins[3]};
-    } else {
-      nfcPins = {nfcGpioPinsPresets[miscConfig.nfcPinsPreset].gpioPins[1], nfcGpioPinsPresets[miscConfig.nfcPinsPreset].gpioPins[2], nfcGpioPinsPresets[miscConfig.nfcPinsPreset].gpioPins[3]};
-    }
-    std::vector<uint8_t> pins_intersection;
-    std::ranges::set_intersection(ethPins.begin(), ethPins.end(), nfcPins.begin(), nfcPins.end(), std::back_inserter(pins_intersection));
-    if((!pins_intersection.empty() && miscConfig.ethSpiBus == SPI2_HOST)){
-      goto nfc_init;
-    }
-    #if SOC_SPI_PERIPH_NUM > 2
-    else if (pins_intersection.empty() && miscConfig.ethSpiBus == SPI3_HOST) goto nfc_init;
-    #endif
-    else {
-      if(miscConfig.ethSpiBus == SPI2_HOST){
-        ESP_LOGE(TAG, "Ethernet enabled on SPI2 Bus, NFC reader has to use the same GPIO pins as Ethernet");
-      } else {
-        ESP_LOGE(TAG, "Ethernet enabled on SPI3 Bus, NFC reader cannot use the same GPIO pins as Ethernet");
-        for(auto& pin : pins_intersection){
-          ESP_LOGE(TAG, "GPIO Intersection: %d", pin);
-        }
-      }
-    }
-  } else {
-  nfc_init:
-    nfcManager = std::make_unique<NfcManager>(*readerDataManager,
-                                miscConfig.nfcPinsPreset == PIN_UNSET ? miscConfig.nfcGpioPins : nfcGpioPinsPresets[miscConfig.nfcPinsPreset].gpioPins,
-                                miscConfig.nfcReaderType,
-                                miscConfig.nfcIrqPin,
-                                miscConfig.nfcVenPin,
-                                miscConfig.hkAuthPrecomputeEnabled,
-                                miscConfig.nfcFastPollingEnabled);
-    nfcManager->begin();
-  }
+
+  nfcManager = std::make_unique<NfcManager>(*readerDataManager,
+                              miscConfig.nfcPinsPreset == PIN_UNSET ? miscConfig.nfcGpioPins : nfcGpioPinsPresets[miscConfig.nfcPinsPreset].gpioPins,
+                              miscConfig.nfcReaderType,
+                              miscConfig.nfcIrqPin,
+                              miscConfig.nfcVenPin,
+                              miscConfig.hkAuthPrecomputeEnabled,
+                              miscConfig.nfcFastPollingEnabled);
+  nfcManager->begin();
+
   webServerManager->setNfcManager(nfcManager.get());
   webServerManager->setMqttManager(mqttManager.get());
   hardwareManager->begin();
@@ -189,7 +156,6 @@ void setup() {
   }, ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
   pollHS = true;
 }
-
 /**
  * @brief Run the main application loop: service HomeSpan events and yield to the RTOS.
 *


### PR DESCRIPTION
GPIOAllocator is to be in charge of allocating leases for GPIO Pins to any components that needs controlling any of the pins, at the same time maintaining a central repository of who owns what pin to help avoid conflicts and henceforth becomes critical that anytime a pin is assigned, it should be first of all acquired from the allocator.

LIfecycle:
 1. pin acquired from GPIOAllocator and ownership maintained by the returned GPIOLease
 2. Until GPIOLease's is destroyed, the pin is owned
 3. GPIOLease is destructed, pin gets reset and removed from the owners array, releasing the pin for use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized GPIO “pin leases” with ownership tracking to prevent conflicting pin usage.
  * Ethernet and NFC initialization now allocates required GPIOs up front and performs NFC setup consistently at startup.
  * Web configuration now rejects already-owned pins (returning the current owner) and saves changes for any `*Pin`/`*Pins` fields.
  * Added a debug command to query which component owns a specific GPIO pin.
* **Bug Fixes**
  * Updated NFC/tag indicators, NeoPixel control, and lock/control outputs to use leased GPIOs for more reliable signaling and state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->