### PR TITLE
feat(ui): show a scannable HomeKit pairing QR code

### DIFF
--- a/data/bun.lock
+++ b/data/bun.lock
@@ -6,6 +6,7 @@
       "name": "test-svelte-js",
       "dependencies": {
         "@tanstack/svelte-virtual": "^3.13.24",
+        "qrcode-generator": "^2.0.4",
       },
       "devDependencies": {
         "@eslint/compat": "^2.0.5",
@@ -429,6 +430,8 @@
     "prettier-plugin-tailwindcss": ["prettier-plugin-tailwindcss@0.7.2", "", { "peerDependencies": { "@ianvs/prettier-plugin-sort-imports": "*", "@prettier/plugin-hermes": "*", "@prettier/plugin-oxc": "*", "@prettier/plugin-pug": "*", "@shopify/prettier-plugin-liquid": "*", "@trivago/prettier-plugin-sort-imports": "*", "@zackad/prettier-plugin-twig": "*", "prettier": "^3.0", "prettier-plugin-astro": "*", "prettier-plugin-css-order": "*", "prettier-plugin-jsdoc": "*", "prettier-plugin-marko": "*", "prettier-plugin-multiline-arrays": "*", "prettier-plugin-organize-attributes": "*", "prettier-plugin-organize-imports": "*", "prettier-plugin-sort-imports": "*", "prettier-plugin-svelte": "*" }, "optionalPeers": ["@ianvs/prettier-plugin-sort-imports", "@prettier/plugin-hermes", "@prettier/plugin-oxc", "@prettier/plugin-pug", "@shopify/prettier-plugin-liquid", "@trivago/prettier-plugin-sort-imports", "@zackad/prettier-plugin-twig", "prettier-plugin-astro", "prettier-plugin-css-order", "prettier-plugin-jsdoc", "prettier-plugin-marko", "prettier-plugin-multiline-arrays", "prettier-plugin-organize-attributes", "prettier-plugin-organize-imports", "prettier-plugin-sort-imports", "prettier-plugin-svelte"] }, "sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "qrcode-generator": ["qrcode-generator@2.0.4", "", {}, "sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 

--- a/data/package.json
+++ b/data/package.json
@@ -37,6 +37,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@tanstack/svelte-virtual": "^3.13.24"
+    "@tanstack/svelte-virtual": "^3.13.24",
+    "qrcode-generator": "^2.0.4"
   }
 }

--- a/data/src/lib/components/AppMisc.svelte
+++ b/data/src/lib/components/AppMisc.svelte
@@ -15,6 +15,7 @@
 	import { diff } from "$lib/utils/objDiff";
 	import HardwareConfig from "$lib/components/HardwareConfig.svelte";
 	import CertManager from "$lib/components/CertManager.svelte";
+	import PairingQR from "$lib/components/PairingQR.svelte";
 
 	interface Props {
 		misc: MiscConfig;
@@ -361,6 +362,11 @@
 										inputmode="numeric"
 									/>
 								</div>
+							</div>
+
+							<!-- Live pairing QR, derived from the setup code above. -->
+							<div class="mt-2">
+								<PairingQR setupCode={miscConfig.setupCode} />
 							</div>
 
 							<!-- Toggles -->

--- a/data/src/lib/components/PairingQR.svelte
+++ b/data/src/lib/components/PairingQR.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import qrcode from 'qrcode-generator';
+
+	interface Props {
+		/** 8-digit HomeKit setup code, e.g. "46637726". */
+		setupCode: string;
+		/** 4-character Setup ID. HomeSpan's default is "HSPN" unless setQRID() is called. */
+		setupId?: string;
+		/** HAP accessory category. HomeKey-ESP32 registers as Category::Locks = 6. */
+		category?: number;
+	}
+
+	let { setupCode, setupId = 'HSPN', category = 6 }: Props = $props();
+
+	// HAP setup payload, per the HomeKit Accessory Protocol specification:
+	//
+	//   bits 43..45  version   (0)
+	//   bits 39..42  reserved  (0)
+	//   bits 31..38  category
+	//   bits 27..30  flags     (2 = IP/WiFi transport)
+	//   bits  0..26  setup code
+	//
+	// The 9-byte value is base36-encoded, zero-padded to 9 characters, and
+	// prefixed with "X-HM://". The 4-character Setup ID is appended.
+	//
+	// BigInt is required: the payload exceeds 32 bits, and shifting past bit 31
+	// with normal JS numbers silently wraps.
+	const payloadUri = $derived.by(() => {
+		const digits = (setupCode ?? '').replace(/\D/g, '');
+		if (digits.length !== 8) return null;
+
+		const code = BigInt(digits);
+		const value =
+			(BigInt(category) << 31n) | (2n << 27n) | code;
+
+		let encoded = '';
+		let n = value;
+		const alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		while (n > 0n) {
+			encoded = alphabet[Number(n % 36n)] + encoded;
+			n = n / 36n;
+		}
+		encoded = encoded.padStart(9, '0');
+
+		return `X-HM://${encoded}${setupId}`;
+	});
+
+	const svg = $derived.by(() => {
+		if (!payloadUri) return null;
+		// Type 0 = auto-size. 'M' error correction matches what Apple's own
+		// setup labels use.
+		const qr = qrcode(0, 'M');
+		qr.addData(payloadUri);
+		qr.make();
+		return qr.createSvgTag({ cellSize: 4, margin: 4, scalable: true });
+	});
+
+	const formattedCode = $derived.by(() => {
+		const d = (setupCode ?? '').replace(/\D/g, '');
+		return d.length === 8 ? `${d.slice(0, 3)}-${d.slice(3, 5)}-${d.slice(5)}` : setupCode;
+	});
+</script>
+
+<div class="py-2 px-3 bg-base-100 rounded-lg">
+	<p class="text-sm font-medium mb-2">HomeKit Pairing</p>
+
+	{#if svg}
+		<div class="flex flex-col sm:flex-row items-center gap-4">
+			<!-- White backing: QR scanners need light quiet-zone contrast, which a
+			     dark UI theme would otherwise destroy. -->
+			<div class="bg-white p-2 rounded-lg shrink-0 w-40 h-40 [&>svg]:w-full [&>svg]:h-full">
+				{@html svg}
+			</div>
+			<div class="text-center sm:text-left">
+				<p class="text-xs opacity-60 mb-1">Setup code</p>
+				<p class="text-2xl font-mono tracking-wider mb-2">{formattedCode}</p>
+				<p class="text-xs opacity-60">
+					Scan with the Home app, or enter the code manually via
+					<span class="whitespace-nowrap">Add Accessory &rarr; More options</span>.
+				</p>
+				<p class="text-xs opacity-40 mt-2 font-mono break-all">{payloadUri}</p>
+			</div>
+		</div>
+	{:else}
+		<p class="text-xs opacity-60">
+			Set an 8-digit setup code to generate a pairing QR code.
+		</p>
+	{/if}
+</div>


### PR DESCRIPTION
This PR was created with the help of AI, and has been reviewed and tested by me. 

Pairing previously required reading the 8-digit setup code off the settings page and typing it into the Home app by hand. On a headless build with no serial console that code is also the only way in, so a scannable QR removes a real friction point during first setup.

Rendered entirely in the browser from the setup code already returned by GET /config?type=misc -- no firmware change, and it updates live when the code is edited.

Builds the HAP payload per the HomeKit specification:

    bits 43..45  version   (0)
    bits 39..42  reserved  (0)
    bits 31..38  category  (6 = Locks, matching homeSpan.begin(Category::Locks))
    bits 27..30  flags     (2 = IP/WiFi transport)
    bits  0..26  setup code

base36-encoded, zero-padded to 9 characters, prefixed with "X-HM://" and suffixed with the 4-character Setup ID (HomeSpan's DEFAULT_AP_SSID-era default "HSPN", since setQRID() is not called).

BigInt is required: the payload exceeds 32 bits and shifting past bit 31 with JavaScript numbers wraps silently.

Verified end to end -- a lock was paired by scanning the generated code.

Costs ~7.7 KB gzipped (qrcode-generator, MIT, zero dependencies); the web UI bundle grows 95511 -> 103255 bytes against a 128 KB littlefs partition.

The QR is drawn on a white backing: scanners need a light quiet zone, which the dark theme would otherwise destroy.

<img width="2322" height="2326" alt="image" src="https://github.com/user-attachments/assets/64f71b43-0d5b-4196-a13b-7578ebed9bc9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live QR code for HomeKit pairing beneath the setup code.
  * QR codes include pairing instructions and display the pairing URI when available.
  * Added validation and a fallback message for invalid setup codes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->