### PR TITLE
fix(build): declare the real minimum ESP-IDF version (5.4, not 5.3)

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,6 +1,6 @@
 dependencies:
   idf:
-    version: '>=5.3.0'
+    version: '>=5.4.0'
   espressif/arduino-esp32: ==3.3.5
   joltwallet/littlefs: ^1.20.1
   espp/serialization: ^1.0.22


### PR DESCRIPTION
Debugged this build failure using AI, and verified the fix myself.

Building against ESP-IDF v5.3.2, which idf_component.yml claimed to support, fails in two bundled components:

    components/pn7160/src/spi.cpp:7:10: fatal error:
        esp_log_buffer.h: No such file or directory
    components/pn532_hal/src/spi.cpp:97:30: error:
        'spi_bus_dma_memory_alloc' was not declared in this scope

Both APIs were introduced in v5.4 -- verified against the esp-idf tree:

    v5.3.2   esp_log_buffer.h MISSING   spi_bus_dma_memory_alloc MISSING
    v5.4     esp_log_buffer.h present   spi_bus_dma_memory_alloc present
    v5.5.4   esp_log_buffer.h present   spi_bus_dma_memory_alloc present

.github/workflows/esp32.yml already pins esp_idf_version: v5.5.4, so CI was green while the declared requirement was not buildable. Anyone following idf_component.yml hit a compile error before reaching their own code.

Verified: clean build on v5.5.4 (gcc 14.2.0), esp32s3 target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported ESP-IDF version to 5.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->