### PR TITLE
chore: ignore build artifacts and fix logs/ ignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .vscode/
 .idea/
 .zed/
-./logs/
+logs/
 .cache/
 compile_commands.json
 src/config.h
@@ -12,4 +12,5 @@ managed_components/
 gha-creds-*.json
 docs/public
 .direnv/
-build-*/
+build-*/.pio/
+*-merged.bin


### PR DESCRIPTION
These are mostly cosmetic changes that helped me keep the checked out repo status clean.

"./logs/" never matched anything: git pathspecs in .gitignore are relative to the file's directory already, so the leading "./" makes the pattern inert and the directory showed up as untracked.

Also ignores:
- .pio/  - stale PlatformIO output; the project moved to bare esp-idf in efa722f but the directory is still generated by some IDE integrations
- *-merged.bin - single-image builds produced by "esptool merge_bin" for first-time USB flashing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignored-file rules to exclude log directories, PlatformIO build artifacts, and merged binary files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->