### PR TITLE
fix(gpio): stop reserving GPIO 33-37 on quad-flash ESP32-S3 boards

### DIFF
--- a/main/include/GPIOAllocator.hpp
+++ b/main/include/GPIOAllocator.hpp
@@ -35,9 +35,21 @@ inline constexpr uint8_t STRAPPING_PINS[] = {
   2, 4, 5, 6, 7, 8, 9, 20, 21
 };
 #elifdef CONFIG_IDF_TARGET_ESP32S3
+// GPIO 33-37 carry the additional data lines used by octal SPI flash and octal
+// PSRAM. On quad-flash parts without octal PSRAM they are ordinary GPIOs, and
+// boards do use them: the M5Stack AtomS3 Lite (ESP32-S3FN8, in-package quad
+// flash, no PSRAM) wires its RGB LED to GPIO 35. Reserving them unconditionally
+// makes that LED impossible to drive, and RESTRICTED_PINS has no override --
+// overrideStrappingRestriction only downgrades STRAPPING_PINS to a warning.
+#if defined(CONFIG_ESPTOOLPY_OCT_FLASH) || defined(CONFIG_SPIRAM_MODE_OCT)
 inline constexpr uint8_t RESTRICTED_PINS[] = {
   9, 10, 11, 12, 13, 14, 19, 20, 33, 34, 35, 36, 37, 38, 39
 };
+#else
+inline constexpr uint8_t RESTRICTED_PINS[] = {
+  9, 10, 11, 12, 13, 14, 19, 20, 38, 39
+};
+#endif
 inline constexpr uint8_t STRAPPING_PINS[] = {
   0, 3, 43, 44, 45, 46, 47, 48
 };


### PR DESCRIPTION
After observing my LED no longer worked I used AI to debug and create a generic fix. 

4030ce1 introduced RESTRICTED_PINS and listed 33-39 for the ESP32-S3. Those extra data lines are only in use with octal SPI flash or octal PSRAM. On the far more common quad-flash parts they are ordinary GPIOs, and boards rely on that: the M5Stack AtomS3 Lite (ESP32-S3FN8, in-package quad flash, no PSRAM) wires its RGB LED to GPIO 35.

Since 4030ce1 that LED cannot be driven at all:

    D GPIOAllocator: Allocating GPIO Pin 35 for 'NEOPIXEL_PIN'
    E GPIOAllocator: GPIO Pin 35 restricted, reserved by internal function!

and there is no way around it. overrideStrappingRestriction only downgrades STRAPPING_PINS to a warning; RESTRICTED_PINS is an unconditional rejection. A user whose LED worked before that commit has no configuration that restores it, and the failure is only visible as a debug-level allocation line followed by an error, well before the web log is reachable.

33-37 are now reserved only when octal flash or octal PSRAM is configured. 26-32 (SPI0/1 flash) are untouched, as are 19/20 (USB).

Not changed, but worth a look: 9-14 are listed as restricted for the S3 too. Those are general-purpose on that target -- the range is restricted on the C3 -- so the S3 list may have inherited them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated ESP32-S3 GPIO availability to accurately reflect the configured flash and PSRAM hardware.
  * GPIOs 33–37 are now available in non-octal configurations while remaining restricted when required.
  * GPIOs 38–39 remain restricted in all configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->