### PR TITLE
feat(diag): store a core dump on panic and expose it over HTTP

### DIFF
--- a/docs/coredump.md
+++ b/docs/coredump.md
@@ -1,0 +1,142 @@
+# Core dumps
+
+When the firmware panics, the device stores an ELF core dump in flash and
+survives the reboot with it intact. The HTTP API decodes it on-device, so the
+common question — *which task crashed, and where* — is answered without
+installing anything.
+
+This exists because a board with no reachable serial port otherwise gives you
+nothing: the reset reason says `PANIC` and stops there. The rolling log buffer
+shows what the device was doing; the core dump shows where it died.
+
+## Enabling it
+
+Core dump support is compiled in, but the partition table has to be written
+once, because a 128 KB dump partition does not fit the stock layout. The app
+slots shrink from 1920 KB to 1856 KB to make room:
+
+```text
+nvs       0x009000..0x019000    64 K   unchanged
+otadata   0x019000..0x01B000     8 K   unchanged
+app0      0x020000..0x1F0000  1856 K   unchanged offset, 64 K smaller
+app1      0x1F0000..0x3C0000  1856 K   moved
+coredump  0x3C0000..0x3E0000   128 K   new
+spiffs    0x3E0000..0x400000   128 K   unchanged
+```
+
+This particular split was chosen so that `nvs`, `otadata` and `spiffs` all keep
+their existing offsets -- only `app1` moves. **HomeKit pairing, HomeKey reader
+credentials and the web assets are therefore untouched**, and there is nothing
+to back up and restore.
+
+Application headroom drops from about 10% to 7% as a result, which is the real
+cost of this feature.
+
+Flash the changed regions only, leaving NVS alone:
+
+```bash
+esptool.py --chip esp32s3 -p /dev/cu.usbmodem* erase_region 0x3C0000 0x20000
+esptool.py --chip esp32s3 -p /dev/cu.usbmodem* write_flash \
+    0x0      build/bootloader/bootloader.bin \
+    0x8000   build/partition_table/partition-table.bin \
+    0x19000  build/ota_data_initial.bin \
+    0x20000  build/HomeKey-ESP32.bin
+```
+
+The erase removes data left by the old `app1` layout. It is required because
+unread core dumps are deliberately not overwritten.
+
+`0x9000` (NVS) is deliberately absent. Do **not** flash a merged image here:
+merged images pad the gaps with `0xFF` and would erase NVS, taking the pairing
+with it.
+
+Belt and braces, before you start:
+
+```bash
+esptool.py --chip esp32s3 -p /dev/cu.usbmodem* read_flash 0x9000 0x10000 nvs-backup.bin
+# restore, only if something goes wrong:
+# esptool.py --chip esp32s3 -p /dev/cu.usbmodem* write_flash 0x9000 nvs-backup.bin
+```
+
+After that, firmware updates continue over OTA as before.
+
+## Reading a dump
+
+Over HTTP — the summary is already decoded, so this is usually all you need:
+
+```bash
+curl -s -u webUsername:webPassword http://<device>/coredump/info | jq
+```
+
+Omit `-u webUsername:webPassword` when web authentication is disabled.
+
+```json
+{
+  "supported": true,
+  "available": true,
+  "size": 8192,
+  "valid": true,
+  "panicReason": "StoreProhibited",
+  "task": "nfc_poll",
+  "pc": "0x420a1c34",
+  "appElfSha256": "3f2a...",
+  "backtrace": ["0x420a1c34", "0x420a0f18", "0x4038b2a0"],
+  "backtraceCorrupted": false,
+  "runningVersion": "dev-31-gabc1234"
+}
+```
+
+`backtrace` is present on Xtensa targets (ESP32, ESP32-S3). RISC-V targets
+(ESP32-C3, C6) record a raw stack dump instead of an unwound backtrace, so those
+need the offline path below.
+
+## Turning addresses into file:line
+
+The addresses mean nothing on their own. Resolve them against **the exact ELF
+that was running when it crashed** — check `appElfSha256` against that build.
+
+```bash
+xtensa-esp32s3-elf-addr2line -pfiaC -e build/HomeKey-ESP32.elf \
+    0x420a1c34 0x420a0f18 0x4038b2a0
+```
+
+Use `riscv32-esp-elf-addr2line` on C3/C6. Both are on `PATH` after
+`. $IDF_PATH/export.sh`.
+
+## Full offline decode
+
+For a complete view — all task backtraces, registers, memory regions — download
+the raw image and decode it:
+
+```bash
+curl -u webUsername:webPassword -o coredump.elf http://<device>/coredump
+esp-coredump info_corefile -c coredump.elf -t elf build/HomeKey-ESP32.elf
+```
+
+`esp-coredump` ships with ESP-IDF. `dbg_corefile` instead of `info_corefile`
+drops you into GDB against the crash state.
+
+## Clearing it
+
+The first dump is kept and later panics are **not** recorded until it is
+cleared — the first crash is usually the informative one, and without this a
+reboot loop would immediately bury it.
+
+```bash
+curl -u webUsername:webPassword -X POST http://<device>/coredump/erase
+```
+
+## Caveats
+
+- The partition is 128 KB with `CONFIG_ESP_COREDUMP_MAX_TASKS_NUM` at 16. ESP-IDF
+  calculates the complete image size before writing it; if that image exceeds
+  the partition, it writes no new dump. Keep the task count and stack sizes in
+  mind when adding long-lived tasks.
+- A dump whose checksum fails remains available from `/coredump`, but
+  `/coredump/info` does not attempt to decode corrupt ELF data.
+- `appElfSha256` is worth checking every time. Symbolicating against a rebuilt
+  ELF produces plausible, wrong answers.
+- There is no web UI panel for this yet, only the HTTP API above. A panel
+  belongs next to the rolling log buffer in the Logs view; both touch the same
+  component, so it is left to whichever of the two changes lands second rather
+  than creating an avoidable merge conflict.

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -4,7 +4,7 @@ idf_component_register(SRCS "main.cpp" "app_events.cpp" "app_event_loop.cpp" "Co
                     "ConsoleLogSinker.cpp" "GPIOAllocator.cpp"
                     INCLUDE_DIRS "include"
                     PRIV_REQUIRES HomeSpan pn532_hal pn7160 DigitalDoorKey esp_https_server mqtt libsodium
-                    msgpack-c json loggable loggable_espidf esp_wifi dns_server)
+                    msgpack-c json loggable loggable_espidf esp_wifi dns_server espcoredump app_update)
 
 include(FetchContent)
 

--- a/main/WebServerManager.cpp
+++ b/main/WebServerManager.cpp
@@ -10,6 +10,9 @@
 #include "fmt/ranges.h"
 #include "WebServerManager.hpp"
 #include "ConfigManager.hpp"
+#include "esp_app_desc.h"
+#include "esp_core_dump.h"
+#include <cinttypes>
 #include "HomeSpan.h"
 #include "MqttManager.hpp"
 #include "NfcManager.hpp"
@@ -299,6 +302,9 @@ void WebServerManager::setupRoutes() {
       {"/config/save", HTTP_POST, handleSaveConfig, this},
       {"/eth_get_config", HTTP_GET, handleGetEthConfig, this},
       {"/nfc_get_presets", HTTP_GET, handleGetNfcPresets, this},
+      {"/coredump/info", HTTP_GET, handleCoreDumpInfo, this},
+      {"/coredump", HTTP_GET, handleCoreDumpDownload, this},
+      {"/coredump/erase", HTTP_POST, handleCoreDumpErase, this},
 
       // Action endpoints
       {"/reboot_device", HTTP_POST, handleReboot, this},
@@ -624,6 +630,182 @@ esp_err_t WebServerManager::handleGetConfig(httpd_req_t *req) {
   std::string response = cjson_to_string_and_free(res);
   httpd_resp_send(req, response.c_str(), HTTPD_RESP_USE_STRLEN);
   return ESP_OK;
+}
+
+/**
+ * @brief Report the stored core dump, decoded on the device.
+ *
+ * A panic otherwise leaves only the reset reason -- "PANIC" without a location.
+ * Decoding the summary here rather than shipping the raw image means the common
+ * case needs no host tooling at all: the response already names the faulting
+ * task and carries the backtrace addresses, and only turning those addresses
+ * into file:line requires addr2line.
+ */
+esp_err_t WebServerManager::handleCoreDumpInfo(httpd_req_t *req) {
+  WebServerManager *instance = getInstance(req);
+  if (!instance) {
+    httpd_resp_send_500(req);
+    return ESP_FAIL;
+  }
+  if (!instance->basicAuth(req)) {
+    return sendAuthFailure(req);
+  }
+
+  cJSON *root = cJSON_CreateObject();
+
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+  cJSON_AddBoolToObject(root, "supported", true);
+
+  size_t addr = 0, size = 0;
+  const esp_err_t present = esp_core_dump_image_get(&addr, &size);
+  const bool available = (present == ESP_OK && size > 0);
+  cJSON_AddBoolToObject(root, "available", available);
+
+  if (available) {
+    cJSON_AddNumberToObject(root, "size", size);
+    // A corrupt image can still be downloaded for inspection, but ESP-IDF's
+    // on-device ELF parser assumes valid offsets and must not receive it.
+    const bool valid = esp_core_dump_image_check() == ESP_OK;
+    cJSON_AddBoolToObject(root, "valid", valid);
+
+    if (valid) {
+      char reason[64] = {0};
+      if (esp_core_dump_get_panic_reason(reason, sizeof(reason)) == ESP_OK) {
+        cJSON_AddStringToObject(root, "panicReason", reason);
+      }
+
+#if CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
+      esp_core_dump_summary_t *summary = static_cast<esp_core_dump_summary_t *>(
+          calloc(1, sizeof(esp_core_dump_summary_t)));
+      if (summary) {
+        if (esp_core_dump_get_summary(summary) == ESP_OK) {
+          cJSON_AddStringToObject(root, "task", summary->exc_task);
+          char pc[16];
+          snprintf(pc, sizeof(pc), "0x%08" PRIx32, summary->exc_pc);
+          cJSON_AddStringToObject(root, "pc", pc);
+
+          // The dump records which build produced it. Comparing this against the
+          // running firmware catches the classic mistake of symbolicating a crash
+          // against an ELF that has since been rebuilt.
+          char sha[sizeof(summary->app_elf_sha256) + 1] = {0};
+          memcpy(sha, summary->app_elf_sha256, sizeof(summary->app_elf_sha256));
+          cJSON_AddStringToObject(root, "appElfSha256", sha);
+
+#if CONFIG_IDF_TARGET_ARCH_XTENSA
+          cJSON *bt = cJSON_AddArrayToObject(root, "backtrace");
+          for (uint32_t i = 0; i < summary->exc_bt_info.depth && i < 16; i++) {
+            char f[16];
+            snprintf(f, sizeof(f), "0x%08" PRIx32, summary->exc_bt_info.bt[i]);
+            cJSON_AddItemToArray(bt, cJSON_CreateString(f));
+          }
+          cJSON_AddBoolToObject(root, "backtraceCorrupted", summary->exc_bt_info.corrupted);
+#else
+          // RISC-V summaries carry a raw stack dump rather than an unwound
+          // backtrace; that has to be decoded from the downloaded image.
+          cJSON_AddNullToObject(root, "backtrace");
+          cJSON_AddStringToObject(root, "backtraceNote",
+                                  "RISC-V: no on-device unwind, decode the downloaded image");
+#endif
+        }
+        free(summary);
+      }
+#endif  // CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
+    }
+  }
+#else
+  cJSON_AddBoolToObject(root, "supported", false);
+  cJSON_AddBoolToObject(root, "available", false);
+#endif
+
+  const esp_app_desc_t *app = esp_app_get_description();
+  cJSON_AddStringToObject(root, "runningVersion", app->version);
+
+  char *out = cJSON_PrintUnformatted(root);
+  httpd_resp_set_type(req, "application/json");
+  esp_err_t rc = httpd_resp_sendstr(req, out ? out : "{}");
+  cJSON_free(out);
+  cJSON_Delete(root);
+  return rc;
+}
+
+/** Stream the raw core dump image so it can be decoded with esp-coredump. */
+esp_err_t WebServerManager::handleCoreDumpDownload(httpd_req_t *req) {
+  WebServerManager *instance = getInstance(req);
+  if (!instance) {
+    httpd_resp_send_500(req);
+    return ESP_FAIL;
+  }
+  if (!instance->basicAuth(req)) {
+    return sendAuthFailure(req);
+  }
+
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+  size_t addr = 0, size = 0;
+  if (esp_core_dump_image_get(&addr, &size) != ESP_OK || size == 0) {
+    httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "no core dump stored");
+    return ESP_FAIL;
+  }
+  const esp_partition_t *part = esp_partition_find_first(
+      ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_COREDUMP, nullptr);
+  if (!part) {
+    httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "no coredump partition");
+    return ESP_FAIL;
+  }
+
+  httpd_resp_set_type(req, "application/octet-stream");
+  httpd_resp_set_hdr(req, "Content-Disposition", "attachment; filename=\"coredump.elf\"");
+
+  // Streamed in chunks: the dump can be the whole partition and there is no
+  // reason to hold a second copy in heap on a device that has just crashed.
+  constexpr size_t kChunk = 1024;
+  uint8_t buf[kChunk];
+  size_t off = 0;
+  while (off < size) {
+    const size_t n = (size - off) < kChunk ? (size - off) : kChunk;
+    if (esp_partition_read(part, off, buf, n) != ESP_OK) {
+      ESP_LOGE(TAG, "core dump read failed at offset %u", static_cast<unsigned>(off));
+      return ESP_FAIL;
+    }
+    if (httpd_resp_send_chunk(req, reinterpret_cast<const char *>(buf), n) != ESP_OK) {
+      return ESP_FAIL;
+    }
+    off += n;
+  }
+  return httpd_resp_send_chunk(req, nullptr, 0);
+#else
+  httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "core dump support not built in");
+  return ESP_FAIL;
+#endif
+}
+
+/**
+ * @brief Erase the stored core dump.
+ *
+ * Needed because CONFIG_ESP_COREDUMP_FLASH_NO_OVERWRITE keeps the first dump:
+ * without an explicit erase, later crashes would not be recorded.
+ */
+esp_err_t WebServerManager::handleCoreDumpErase(httpd_req_t *req) {
+  WebServerManager *instance = getInstance(req);
+  if (!instance) {
+    httpd_resp_send_500(req);
+    return ESP_FAIL;
+  }
+  if (!instance->basicAuth(req)) {
+    return sendAuthFailure(req);
+  }
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+  const esp_err_t err = esp_core_dump_image_erase();
+  httpd_resp_set_type(req, "application/json");
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "core dump erase failed: %s", esp_err_to_name(err));
+    return httpd_resp_sendstr(req, "{\"success\":false}");
+  }
+  ESP_LOGI(TAG, "core dump erased; the next panic will be recorded");
+  return httpd_resp_sendstr(req, "{\"success\":true}");
+#else
+  httpd_resp_set_type(req, "application/json");
+  return httpd_resp_sendstr(req, "{\"success\":false,\"error\":\"not built in\"}");
+#endif
 }
 
 esp_err_t WebServerManager::handleGetNfcPresets(httpd_req_t *req) {

--- a/main/include/WebServerManager.hpp
+++ b/main/include/WebServerManager.hpp
@@ -118,6 +118,9 @@ private:
   static esp_err_t handleGetConfig(httpd_req_t *req);
   static esp_err_t handleGetEthConfig(httpd_req_t *req);
   static esp_err_t handleGetNfcPresets(httpd_req_t *req);
+  static esp_err_t handleCoreDumpInfo(httpd_req_t *req);
+  static esp_err_t handleCoreDumpDownload(httpd_req_t *req);
+  static esp_err_t handleCoreDumpErase(httpd_req_t *req);
   static esp_err_t handleClearConfig(httpd_req_t *req);
   static esp_err_t handleSaveConfig(httpd_req_t *req);
   static esp_err_t handleReboot(httpd_req_t *req);

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -103,3 +103,24 @@ CONFIG_ESP_RMAKER_FACTORY_PARTITION_NAME=""
 CONFIG_ESP_RMAKER_FACTORY_NAMESPACE=""
 CONFIG_ESP_RMAKER_DEF_TIMEZONE=""
 CONFIG_ESP_RMAKER_SNTP_SERVER_NAME=""
+
+# Core dump to flash.
+#
+# The device has no reachable serial port in normal use, so a panic leaves no
+# backtrace: the reset reason alone says "PANIC" without saying where. This
+# stores an ELF core dump in a 128K partition created by shrinking both OTA app
+# slots by 64K. The web API exposes the decoded summary plus the raw image.
+#
+# ELF rather than BIN: esp_core_dump_get_summary() only works with ELF, and that
+# is what lets the device report the faulting task and backtrace itself instead
+# of requiring the user to run esp-coredump for every crash.
+CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y
+CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF=y
+CONFIG_ESP_COREDUMP_CHECKSUM_CRC32=y
+CONFIG_ESP_COREDUMP_DECODE_INFO=y
+# Bound the dump to the tasks that matter. If the calculated image exceeds the
+# partition, ESP-IDF does not write a partial dump.
+CONFIG_ESP_COREDUMP_MAX_TASKS_NUM=16
+# Do not overwrite an unread dump: the first crash is usually the informative
+# one, and later reboots would otherwise bury it.
+CONFIG_ESP_COREDUMP_FLASH_NO_OVERWRITE=y

--- a/with_ota.csv
+++ b/with_ota.csv
@@ -1,6 +1,11 @@
-# Name, Type, SubType, Offset, Size, Flags
+# Name,   Type, SubType, Offset,  Size, Flags
+# App slots are 1856K rather than 1920K so a 128K core dump partition fits.
+# Chosen because it leaves nvs, otadata and spiffs at their existing offsets --
+# only app1 moves -- so enabling core dumps does not disturb HomeKit pairing,
+# reader credentials or the web assets.
 nvs,data,nvs,,0x10000,,
 otadata,data,ota,,0x2000,,
-app0,app,ota_0,,0x1E0000,,
-app1,app,ota_1,,0x1E0000,,
+app0,app,ota_0,0x20000,0x1D0000,,
+app1,app,ota_1,,0x1D0000,,
+coredump,data,coredump,,0x20000,,
 spiffs,data,spiffs,,0x20000,,


### PR DESCRIPTION
This helped me identify source of panics. But perhaps it is too much of a developer feature to include? In any case I wanted to share the code because it is helpful to debug crashes.

## summary 

A panic on a board with no reachable serial port currently leaves only the reset reason. Enable ESP-IDF ELF core dumps in flash so crash state survives the reboot and can be inspected without reproducing the failure while tethered.

Expose authenticated-by-configuration diagnostic endpoints:

    GET  /coredump/info    decoded summary as JSON
    GET  /coredump         raw ELF image for offline decoding
    POST /coredump/erase   discard the stored dump

The summary reports the panic reason, faulting task, program counter, build ELF hash, and an Xtensa backtrace. RISC-V targets direct users to offline decoding because their summaries contain a raw stack dump instead. Corrupt images remain downloadable but are not passed to ESP-IDF parsers.

Reserve a 128 KB coredump partition at 0x3C0000 by shrinking both OTA app slots from 1920 KB to 1856 KB. app0, NVS, otadata, and SPIFFS retain their offsets; app1 moves from 0x200000 to 0x1F0000. Adopting the layout therefore requires a one-time flash of the revised partition table, initialized OTA data, and an app image. NVS remains untouched, preserving HomeKit pairing and reader credentials, while application headroom drops from roughly 10% to 7%.

CONFIG_ESP_COREDUMP_FLASH_NO_OVERWRITE preserves the first crash until POST /coredump/erase rearms collection. Raw dumps are streamed from flash in 1 KB chunks, and appElfSha256 identifies the exact ELF required for reliable symbolication. docs/coredump.md documents migration, addr2line, and esp-coredump usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added web-based crash-dump information, including fault details, task data, firmware version, and backtraces.
  * Added options to download raw crash dumps and erase stored dumps.
  * Crash dumps are preserved until explicitly cleared and protected with integrity checks.
  * Added safeguards for unavailable, invalid, corrupted, or mismatched crash-dump data.

* **Documentation**
  * Added guidance for configuring, flashing, backing up, decoding, analyzing, and troubleshooting firmware crash dumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->